### PR TITLE
add organic redis ttl

### DIFF
--- a/services/video_scheduler/redis_utils.py
+++ b/services/video_scheduler/redis_utils.py
@@ -4,6 +4,7 @@ from vidaio_subnet_core import CONFIG
 from typing import Dict, List, Optional
 
 REDIS_CONFIG = CONFIG.redis
+REDIS_TTL = REDIS_CONFIG.redis_ttl #TTL in seconds
 
 def get_redis_connection() -> redis.Redis:
     """
@@ -26,6 +27,7 @@ def push_organic_upscaling_chunk(r: redis.Redis, data: Dict[str, str]) -> None:
         data (Dict[str, str]): Organic upscaling chunk dictionary to push
     """
     r.rpush(REDIS_CONFIG.organic_upscaling_queue_key, json.dumps(data))
+    r.expire(REDIS_CONFIG.organic_upscaling_queue_key, REDIS_TTL)
     print("Pushed organic upscaling chunk correctly in the Redis queue")
 
 def push_organic_compression_chunk(r: redis.Redis, data: Dict[str, str]) -> None:
@@ -37,6 +39,7 @@ def push_organic_compression_chunk(r: redis.Redis, data: Dict[str, str]) -> None
         data (Dict[str, str]): Organic compression chunk dictionary to push
     """
     r.rpush(REDIS_CONFIG.organic_compression_queue_key, json.dumps(data))
+    r.expire(REDIS_CONFIG.organic_compression_queue_key, REDIS_TTL)
     print("Pushed organic compression chunk correctly in the Redis queue")
 
 def push_5s_chunks(r: redis.Redis, data_list: List[Dict[str, str]]) -> None:

--- a/services/video_scheduler/server.py
+++ b/services/video_scheduler/server.py
@@ -291,7 +291,7 @@ def api_get_organic_upscaling_queue_size():
 @app.post("/api/push_result")
 def api_push_result(payload: InsertResultRequest):
     """
-    Save video processing result to Redis.
+    Save video processing result to Redis with expiry.
     """
     r = get_redis_connection()
     result_key = f"result:{payload.original_video_url}"
@@ -302,6 +302,7 @@ def api_push_result(payload: InsertResultRequest):
         "task_id": payload.task_id,
     }
     r.hmset(result_key, result_data)
+    r.expire(result_key, CONFIG.redis.redis_ttl)
     return {"message": "Result saved successfully"}
 
 

--- a/vidaio_subnet_core/configs/redis.py
+++ b/vidaio_subnet_core/configs/redis.py
@@ -7,6 +7,7 @@ class RedisConfig(BaseModel):
     port: int = Field(default=6379)
     db: int = Field(default=0)
     delete_after_second: int = Field(default=600)
+    redis_ttl: int = Field(default= 60 * 60 * 6) # 6 hours
     organic_upscaling_queue_key: str = Field(default="organic_upscaling_queue")
     organic_compression_queue_key: str = Field(default="organic_compression_queue")
     synthetic_5s_clip_queue_key: str = Field(default="5s_clips")


### PR DESCRIPTION
how to test:
- switch to branch from setup running on `main`, adjust `redis_ttl` in code to 60 * 5 (for 5 minutes TTL)
- restart `organic-gateway ` pm2 process: `pm2 delete organic-gateway && pm2 start "PYTHONPATH=. python services/organic_gateway/server.py" --name organic-gateway`
- make lightweight organic request from webUI, one expected to complete within 5 minutes, note the `task_id` returned in API calls to validator in Chrome Developer tools
- the request should succeed
- on validator instance, check entries with `task_id`, example: `redis-cli --scan --pattern '*4ec275e1-cbff-4e9d-8ade-12a0218e138b*'`, this should return empty result after TTL and the following before that:
 ```
"task_result:4ec275e1-cbff-4e9d-8ade-12a0218e138b"
"task:4ec275e1-cbff-4e9d-8ade-12a0218e138b"
```