### PR TITLE
update organic upscaling scoring

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -284,9 +284,9 @@ class Validator(base.BaseValidator):
 
             batch_processed_time = time.time() - batch_start_time
             
-            sleep_time = 300 - batch_processed_time
+            sleep_time = random.uniform(300, 480) - batch_processed_time
             logger.info(f"Completed upscaling batch within {batch_processed_time:.2f} seconds")
-            logger.info(f"Sleeping for {sleep_time:.2f} seconds before next upscaling batch")
+            logger.info(f"Sleeping for 5-8 minutes before next upscaling batch")
             
             await asyncio.sleep(sleep_time)
 
@@ -342,10 +342,10 @@ class Validator(base.BaseValidator):
             asyncio.create_task(self.score_compressions(uids, responses, payload_urls, reference_video_paths, timestamp, video_ids, uploaded_object_names, vmaf_threshold, round_id))
 
             batch_processed_time = time.time() - batch_start_time
-            sleep_time = 300 - batch_processed_time
+            sleep_time = random.uniform(300, 480) - batch_processed_time
 
             logger.info(f"Completed compression batch within {batch_processed_time:.2f} seconds")
-            logger.info(f"Sleeping for {sleep_time:.2f} seconds before next compression batch")
+            logger.info(f"Sleeping for 5-8 minutes before next compression batch")
             
             await asyncio.sleep(sleep_time)
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -30,6 +30,9 @@ VMAF_QUALITY_THRESHOLDS = [
     95, #High
 ]
 
+SLEEP_TIME_LOW = 60 * 5 # 5 minutes
+SLEEP_TIME_HIGH = 60 * 8 # 8 minutes
+
 class Validator(base.BaseValidator):
     def __init__(self):
         super().__init__()
@@ -284,7 +287,7 @@ class Validator(base.BaseValidator):
 
             batch_processed_time = time.time() - batch_start_time
             
-            sleep_time = random.uniform(300, 480) - batch_processed_time
+            sleep_time = random.uniform(SLEEP_TIME_LOW, SLEEP_TIME_HIGH) - batch_processed_time
             logger.info(f"Completed upscaling batch within {batch_processed_time:.2f} seconds")
             logger.info(f"Sleeping for 5-8 minutes before next upscaling batch")
             
@@ -342,7 +345,7 @@ class Validator(base.BaseValidator):
             asyncio.create_task(self.score_compressions(uids, responses, payload_urls, reference_video_paths, timestamp, video_ids, uploaded_object_names, vmaf_threshold, round_id))
 
             batch_processed_time = time.time() - batch_start_time
-            sleep_time = random.uniform(300, 480) - batch_processed_time
+            sleep_time = random.uniform(SLEEP_TIME_LOW, SLEEP_TIME_HIGH) - batch_processed_time
 
             logger.info(f"Completed compression batch within {batch_processed_time:.2f} seconds")
             logger.info(f"Sleeping for 5-8 minutes before next compression batch")

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -1344,13 +1344,16 @@ async def score_organics_upscaling(request: OrganicsUpscalingScoringRequest) -> 
             # Final scoring based on ClipIQ scores
             if dist_clipiqa_score > ref_clipiqa_score:
                 final_score = 3
-                reason = "distorted better than reference"
-            elif dist_clipiqa_score >= ref_upscaled_clipiqa_score + 0.008:
+                reason = "upscaled better than reference"
+            elif dist_clipiqa_score > (ref_upscaled_clipiqa_score * 1.05):
                 final_score = 2
-                reason = "distorted between reference and upscaled+0.008"
-            else:
+                reason = "upscaled at least 5% better than ffmpeg upscaled"
+            elif dist_clipiqa_score > (ref_upscaled_clipiqa_score):
                 final_score = 1
-                reason = "distorted below upscaled+0.008"
+                reason = "Better than ffmpeg upscaled"
+            else:
+                final_score = 0
+                reason = "Worse than ffmpeg upscaled"
             
             print(f"Final score: {final_score} ({reason})")
             

--- a/vidaio_subnet_core/validating/managing/miner_manager.py
+++ b/vidaio_subnet_core/validating/managing/miner_manager.py
@@ -878,6 +878,7 @@ class MinerManager:
                 # Convert organic scores to synthetic-like format
 
                 acc_score = 0.0
+                current_score = miner.accumulate_score
 
                 if score == 3.0:
                     organic_s_f = 0.4
@@ -885,7 +886,6 @@ class MinerManager:
                     organic_s_l = 0.5
                     success = True
 
-                    current_score = miner.accumulate_score
                     boost_percentage = 0.03
                     boost_amount = current_score * boost_percentage
                     acc_score = current_score + boost_amount
@@ -904,7 +904,6 @@ class MinerManager:
                     organic_s_l = 0.5   # Moderate length score
                     success = False
 
-                    current_score = miner.accumulate_score
                     panelty_percentage = 0.05
                     panelty_amount = current_score * panelty_percentage
                     acc_score = current_score - panelty_amount
@@ -915,7 +914,6 @@ class MinerManager:
                     organic_s_l = 0.0
                     success = False
 
-                    current_score = miner.accumulate_score
                     panelty_percentage = 0.15  # Deduct 15% of current score
                     panelty_amount = current_score * panelty_percentage
                     acc_score = current_score - panelty_amount
@@ -1038,8 +1036,8 @@ class MinerManager:
                 
                 # Accumulate score with decay factor (same as synthetic)
                 miner.accumulate_score = (
-                    miner.accumulate_score * 0.7
-                    + score_with_multiplier * (1 - 0.7)
+                    miner.accumulate_score * CONFIG.score.decay_factor
+                    + score_with_multiplier * (1 - CONFIG.score.decay_factor)
                 )
                 miner.accumulate_score = max(0, miner.accumulate_score)
                 


### PR DESCRIPTION
- update organic upscaling score to take relative CLIPIQA threshold
- reset organic entries' influence on `accumulate_score` to match synthetics
- randomize synthetic sleep interval