### PR TITLE
revise synth scheduling

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -267,7 +267,7 @@ class Validator(base.BaseValidator):
 
             logger.debug(f"Processing upscaling UIDs in batch: {uids}")
             forward_tasks = [
-                self.dendrite.forward(axons=[axon], synapse=synapse, timeout=50)
+                self.dendrite.forward(axons=[axon], synapse=synapse, timeout=60)
                 for axon, synapse in zip(axons, synapses)
             ]
 
@@ -326,7 +326,7 @@ class Validator(base.BaseValidator):
 
             logger.debug(f"Processing compression UIDs in batch: {uids}")
             forward_tasks = [
-                self.dendrite.forward(axons=[axon], synapse=synapse, timeout=40)
+                self.dendrite.forward(axons=[axon], synapse=synapse, timeout=80)
                 for axon, synapse in zip(axons, synapses)
             ]
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -326,7 +326,7 @@ class Validator(base.BaseValidator):
 
             logger.debug(f"Processing compression UIDs in batch: {uids}")
             forward_tasks = [
-                self.dendrite.forward(axons=[axon], synapse=synapse, timeout=80)
+                self.dendrite.forward(axons=[axon], synapse=synapse, timeout=60)
                 for axon, synapse in zip(axons, synapses)
             ]
 

--- a/vidaio_subnet_core/configs/bandwidth.py
+++ b/vidaio_subnet_core/configs/bandwidth.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 class BandwidthConfig(BaseModel):
     total_requests: int = Field(default=64)
     request_interval: int = Field(default=500)
-    requests_per_synthetic_interval: int = Field(default=20)
+    requests_per_synthetic_interval: int = Field(default=5)
     requests_per_organic_interval: int = Field(default = 30)
     miners_per_task: int = Field(default=2)
     min_stake: int = Field(default=25000)


### PR DESCRIPTION
- revise synthetic batching to have lower size to account for same coldkey receiving a burst of requests causing horizontal scaling
- increase timeouts for synthetic, allowing miners to use lower-end GPUs, reducing running costs