### PR TITLE
validate_dist_encoding_settings revision to use avg_frame_rate

### DIFF
--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -951,7 +951,6 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
         width = video_stream.get("width", 0)
         height = video_stream.get("height", 0)
         container = format_info.get("format_name", "")
-        fps_str = video_stream.get("r_frame_rate", "0/1")
         encoder_tag = ""
 
         def parse_fps(fps_str):
@@ -1138,7 +1137,7 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
         else:
             logger.warning("⚠️ No encoder tag found")
         
-        logger.debug(f"Video analysis: {width}x{height}@{fps_str}, {codec}/{profile}, "
+        logger.debug(f"Video analysis: {width}x{height}@{avg_fps}, {codec}/{profile}, "
                     f"container={container}, color_space={dist_color_space}, "
                     f"SVT-AV1={is_svtav1}")
         
@@ -1149,7 +1148,7 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
         encoder_status = "SVT-AV1" if is_svtav1 else "Other AV1"
 
         bit_rate_display = f"{bit_rate_mbps:.2f}" if bit_rate_mbps is not None else "unknown"
-        status_parts = [f"Valid encoding ({codec}, {width}x{height}, {color_info}, level {level}, fps {fps_str}, bitrate {bit_rate_display} Mbps)"]
+        status_parts = [f"Valid encoding ({codec}, {width}x{height}, {color_info}, level {level}, fps {avg_fps}, bitrate {bit_rate_display} Mbps)"]
         if codec_mode:
             status_parts.append(f"mode={codec_mode}")
         if target_bitrate is not None:

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -1517,7 +1517,7 @@ async def score_upscaling_synthetics(request: UpscalingScoringRequest) -> Upscal
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 5. Validated encoding settings ({encoding_msg}) in {step_time:.2f} seconds.")
 
-            random_frames = sorted(random.sample(range(ref_total_frames), VMAF_SAMPLE_COUNT))
+            random_frames = sorted(random.sample(range(ref_total_frames), min(ref_total_frames, VMAF_SAMPLE_COUNT)))
             logger.info(f"Randomly selected {VMAF_SAMPLE_COUNT} frames for VMAF score: frame list: {random_frames}")
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 6. Selected random frames for VMAF in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
@@ -1864,7 +1864,7 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                 logger.info("Reference file size is 0 or distorted file size >= reference, setting compression rate to 1.0")
 
             # Sample frames for VMAF calculation
-            random_frames = sorted(random.sample(range(ref_total_frames), VMAF_SAMPLE_COUNT))
+            random_frames = sorted(random.sample(range(ref_total_frames), min(ref_total_frames, VMAF_SAMPLE_COUNT)))
             logger.info(f"Randomly selected {VMAF_SAMPLE_COUNT} frames for VMAF score: frame list: {random_frames}")
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 6. Selected random frames for VMAF in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
@@ -2268,7 +2268,7 @@ async def score_organics_upscaling(request: OrganicsUpscalingScoringRequest) -> 
             # Get the number of frames in the clips for Y4M conversion using ffprobe
             ref_clip_frames = get_frame_count(ref_upscaled_clip_path)
 
-            random_frames = sorted(random.sample(range(ref_clip_frames), VMAF_SAMPLE_COUNT))
+            random_frames = sorted(random.sample(range(ref_clip_frames), min(ref_clip_frames, VMAF_SAMPLE_COUNT)))
             
             ref_y4m_path = convert_mp4_to_y4m(ref_upscaled_clip_path, random_frames)
             
@@ -2556,8 +2556,7 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
             
             
             # Ensure we don't sample more frames than available
-            sample_count = min(VMAF_SAMPLE_COUNT, ref_clip_frames)
-            random_frames = sorted(random.sample(range(ref_clip_frames), sample_count))
+            random_frames = sorted(random.sample(range(ref_clip_frames), min(VMAF_SAMPLE_COUNT, ref_clip_frames)))
             ref_y4m_path = convert_mp4_to_y4m(ref_clip_path, random_frames)
             logger.info("The reference video clip has been successfully converted to Y4M format.")
             step_time = time.time() - uid_start_time

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -2267,12 +2267,14 @@ async def score_organics_upscaling(request: OrganicsUpscalingScoringRequest) -> 
             logger.info("Creating Y4M files for VMAF calculation...")
             # Get the number of frames in the clips for Y4M conversion using ffprobe
             ref_clip_frames = get_frame_count(ref_upscaled_clip_path)
+
+            random_frames = sorted(random.sample(range(ref_clip_frames), VMAF_SAMPLE_COUNT))
             
-            ref_y4m_path = convert_mp4_to_y4m(ref_upscaled_clip_path, list(range(ref_clip_frames)))
+            ref_y4m_path = convert_mp4_to_y4m(ref_upscaled_clip_path, random_frames)
             
             # Calculate VMAF score
             logger.info("Calculating VMAF score...")
-            vmaf_score = calculate_vmaf(ref_y4m_path, dist_clip_path, list(range(ref_clip_frames)), neg_model=False)
+            vmaf_score = calculate_vmaf(ref_y4m_path, dist_clip_path, random_frames, neg_model=False)
             
             if vmaf_score is None:
                 vmaf_score = 0.0

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -2561,8 +2561,22 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
             # Calculate VMAF on chunked videos and get Y4M paths for validation
             dist_y4m_path = None
             try:
+                # Calculate corresponding frames for distorted clip based on frame count ratio
+                dist_clip_frames = get_frame_count(dist_clip_path)
+                logger.info(f"Distorted clip has {dist_clip_frames} frames.")
+                
+                if dist_clip_frames > 0 and ref_clip_frames > 0:
+                    scale_ratio = dist_clip_frames / ref_clip_frames
+                    dist_random_frames = sorted([int(f * scale_ratio) for f in random_frames])
+                    # Ensure indices are within bounds
+                    dist_random_frames = [min(f, dist_clip_frames - 1) for f in dist_random_frames]
+                    logger.info(f"Scaled random frames for distorted clip: {dist_random_frames}")
+                else:
+                    dist_random_frames = random_frames
+
                 vmaf_start = time.time()
-                vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_clip_path, random_frames, neg_model=True, return_y4m_path=True)
+                # Pass dist_random_frames for the distorted video extraction
+                vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_clip_path, dist_random_frames, neg_model=True, return_y4m_path=True)
                 vmaf_calc_time = time.time() - vmaf_start
                 logger.info(f"☣️☣️ VMAF calculation took {vmaf_calc_time:.2f} seconds.")
 

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -1016,7 +1016,7 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
 
         ref_fps = get_video_fps(ref_path)
         if abs(avg_fps - ref_fps) > 0.01:
-            errors.append(f"FPS must be {ref_fps}, got {fps_str}")
+            errors.append(f"FPS must be {ref_fps}, got {avg_fps}")
 
         if task == "compression":
             ref_width, ref_height = get_video_dimensions(ref_path)

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -1015,7 +1015,7 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
             logger.warning(f"⚠️ Unknown codec mode: {codec_mode}, skipping bitrate validation")
 
         ref_fps = get_video_fps(ref_path)
-        if abs(avg_fps - ref_fps) > 0.01:
+        if abs(avg_fps - ref_fps) > 0.3:
             errors.append(f"FPS must be {ref_fps}, got {avg_fps}")
 
         if task == "compression":

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -30,7 +30,7 @@ COMPRESSION_RATE_WEIGHT = 0.7  # w_c
 COMPRESSION_VMAF_WEIGHT = 0.3  # w_vmaf
 SOFT_THRESHOLD_MARGIN = 5.0  # Margin below VMAF threshold for soft scoring zone
 
-FRAME_TOLERANCE = 3  # Tolerance in frames for fast ffprobe frame count read
+FRAME_TOLERANCE = 5  # Tolerance in frames for fast ffprobe frame count read
 
 
 app = FastAPI()

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -1058,7 +1058,7 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
                 # Get reference colorspace
                 ref_cmd = [
                     "ffprobe", "-v", "error", "-select_streams", "v:0",
-                    "-show_entries", "stream=color_space,color_primaries,color_transfer,width,height,r_frame_rate,bit_rate",
+                    "-show_entries", "stream=color_space,color_primaries,color_transfer,width,height,r_frame_rate,avg_frame_rate,bit_rate",
                     "-of", "json", ref_path
                 ]
                 ref_result = subprocess.run(ref_cmd, capture_output=True, text=True, 
@@ -1072,6 +1072,7 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
                 ref_width = ref_stream.get("width")
                 ref_height = ref_stream.get("height")
                 ref_fps_raw = ref_stream.get("r_frame_rate")
+                ref_avg_fps_raw = ref_stream.get("avg_frame_rate")
                 ref_bit_rate = ref_stream.get("bit_rate") or ref_info.get("format", {}).get("bit_rate")
                 
                 # Colorspace - mismatch affects color accuracy
@@ -1095,8 +1096,8 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
 
                 # Bits-per-pixel for reference video
                 try:
-                    if ref_bit_rate and ref_fps_raw and ref_width and ref_height:
-                        num, denom = ref_fps_raw.split('/')
+                    if ref_bit_rate and ref_avg_fps_raw and ref_width and ref_height:
+                        num, denom = ref_avg_fps_raw.split('/')
                         ref_fps_val = float(num) / float(denom) if float(denom) != 0 else 0.0
                         if ref_fps_val > 0:
                             ref_bpp = int(ref_bit_rate) / (ref_fps_val * ref_width * ref_height)

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -2561,22 +2561,8 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
             # Calculate VMAF on chunked videos and get Y4M paths for validation
             dist_y4m_path = None
             try:
-                # Calculate corresponding frames for distorted clip based on frame count ratio
-                dist_clip_frames = get_frame_count(dist_clip_path)
-                logger.info(f"Distorted clip has {dist_clip_frames} frames.")
-                
-                if dist_clip_frames > 0 and ref_clip_frames > 0:
-                    scale_ratio = dist_clip_frames / ref_clip_frames
-                    dist_random_frames = sorted([int(f * scale_ratio) for f in random_frames])
-                    # Ensure indices are within bounds
-                    dist_random_frames = [min(f, dist_clip_frames - 1) for f in dist_random_frames]
-                    logger.info(f"Scaled random frames for distorted clip: {dist_random_frames}")
-                else:
-                    dist_random_frames = random_frames
-
                 vmaf_start = time.time()
-                # Pass dist_random_frames for the distorted video extraction
-                vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_clip_path, dist_random_frames, neg_model=True, return_y4m_path=True)
+                vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_clip_path, random_frames, neg_model=True, return_y4m_path=True)
                 vmaf_calc_time = time.time() - vmaf_start
                 logger.info(f"☣️☣️ VMAF calculation took {vmaf_calc_time:.2f} seconds.")
 

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -929,7 +929,7 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
             "-v", "error",
             "-select_streams", "v:0",
             "-show_entries", "stream=codec_name,profile,level,sample_aspect_ratio,pix_fmt,"
-                           "width,height,r_frame_rate,color_space,color_primaries,color_transfer,bit_rate",
+                            "width,height,r_frame_rate,avg_frame_rate,color_space,color_primaries,color_transfer,bit_rate",
             "-show_entries", "format=tags=encoder",
             "-show_format",
             "-of", "json",
@@ -954,6 +954,17 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
         fps_str = video_stream.get("r_frame_rate", "0/1")
         encoder_tag = ""
 
+        def parse_fps(fps_str):
+            try:
+                num, denom = map(float, fps_str.split('/'))
+                return num / denom if denom != 0 else 0.0
+            except (ValueError, ZeroDivisionError):
+                return 0.0
+
+        # Extract both
+        r_fps = parse_fps(video_stream.get("r_frame_rate", "0/1"))
+        avg_fps = parse_fps(video_stream.get("avg_frame_rate", "0/1"))
+
         # Get bitrate (prefer stream-level, fallback to format-level)
         bit_rate = video_stream.get("bit_rate") or format_info.get("bit_rate")
         bit_rate_mbps = None
@@ -965,10 +976,8 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
 
         # Bits-per-pixel for distorted video (requires bitrate, fps, width, height)
         try:
-            num, denom = fps_str.split('/')
-            fps_val = float(num) / float(denom) if float(denom) != 0 else 0.0
-            if bit_rate and fps_val > 0 and width and height:
-                dist_bpp = bit_rate / (fps_val * width * height)
+            if bit_rate and avg_fps > 0 and width and height:
+                dist_bpp = bit_rate / (avg_fps * width * height)
         except Exception:
             pass
 
@@ -1005,9 +1014,9 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
         else:
             logger.warning(f"⚠️ Unknown codec mode: {codec_mode}, skipping bitrate validation")
 
-        ref_fps_str = get_video_fps(ref_path, original_str=True)
-        if fps_str != ref_fps_str:
-            errors.append(f"FPS must be {ref_fps_str}, got {fps_str}")
+        ref_fps = get_video_fps(ref_path, original_str=True)
+        if abs(avg_fps - ref_fps) > 0.01:
+            errors.append(f"FPS must be {ref_fps}, got {fps_str}")
 
         if task == "compression":
             ref_width, ref_height = get_video_dimensions(ref_path)
@@ -1201,12 +1210,12 @@ def get_video_fps(video_path, original_str=False):
             "ffprobe",
             "-v", "error",
             "-select_streams", "v:0",
-            "-show_entries", "stream=r_frame_rate",
+            "-show_entries", "stream=avg_frame_rate",
             "-of", "default=noprint_wrappers=1:nokey=1",
             video_path
         ]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=5)
-        # r_frame_rate returns format like "30000/1001" or "30/1"
+        # avg_frame_rate returns format like "30000/1001" or "30/1"
         fps_str = result.stdout.strip()
         if original_str:
             return fps_str

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -2533,20 +2533,23 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
             logger.info(f"♎️ 6. Selected random start time for video chunks in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Create 0.5-second reference clip
-            ref_clip_path = trim_video(ref_path, start_time, clip_duration)
+            # ref_clip_path = trim_video(ref_path, start_time, clip_duration)
+            ref_clip_path = ref_path
             logger.info(f"Created reference clip: {ref_clip_path}")
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 7. Created reference video clip in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Create 0.5-second distorted clip
-            dist_clip_path = trim_video(dist_path, start_time, clip_duration)
+            # dist_clip_path = trim_video(dist_path, start_time, clip_duration)
+            dist_clip_path = dist_path
             logger.info(f"Created distorted clip: {dist_clip_path}")
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 8. Created distorted video clip in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Get the number of frames in the clips for Y4M conversion
             
-            ref_clip_frames = get_frame_count(ref_clip_path)
+            # ref_clip_frames = get_frame_count(ref_clip_path)
+            ref_clip_frames = ref_total_frames
             logger.info(f"Reference clip has {ref_clip_frames} frames.")
             
             

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -1014,7 +1014,7 @@ def validate_dist_encoding_settings(dist_path: str, ref_path: str, task: str, ta
         else:
             logger.warning(f"⚠️ Unknown codec mode: {codec_mode}, skipping bitrate validation")
 
-        ref_fps = get_video_fps(ref_path, original_str=True)
+        ref_fps = get_video_fps(ref_path)
         if abs(avg_fps - ref_fps) > 0.01:
             errors.append(f"FPS must be {ref_fps}, got {fps_str}")
 

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -49,7 +49,7 @@ def get_video_fps(video_path):
         "ffprobe",
         "-v", "error",
         "-select_streams", "v:0",
-        "-show_entries", "stream=r_frame_rate",
+        "-show_entries", "stream=avg_frame_rate",
         "-of", "default=noprint_wrappers=1:nokey=1",
         video_path
     ]

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -54,6 +54,27 @@ def trim_video(video_path, start_time, trim_duration=1):
 
     return output_path
 
+def get_video_fps(video_path):
+    """
+    Get the frame rate of a video using ffprobe.
+    """
+    cmd = [
+        "ffprobe",
+        "-v", "error",
+        "-select_streams", "v:0",
+        "-show_entries", "stream=r_frame_rate",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        video_path
+    ]
+    try:
+        output = subprocess.check_output(cmd).decode().strip()
+        num, den = map(int, output.split('/'))
+        return num / den
+    except Exception as e:
+        print(f"Error getting FPS for {video_path}: {e}")
+        # Fallback to 30 fps if detection fails, though this might cause drift
+        return 30.0
+
 def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     """
     Converts an MP4 video file to Y4M format using FFmpeg and upscales selected frames.
@@ -74,44 +95,53 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     temp_dir = tempfile.mkdtemp()
     
     try:
-        # 1. Extract specific frames as high-quality PNGs
-        # We use -start_number 0 to ensure sequential naming for the next step
-        # print(f"DEBUG: random_frames: {random_frames}")
+        # 1. Extract specific frames using fast seek (-ss)
         
-        # Use simple eq(n,f) without extra escaping
-        select_expr = "+".join([f"eq(n,{f})" for f in random_frames])
-        # print(f"DEBUG: select_expr: {select_expr}")
+        # Get FPS to calculate timestamps
+        fps = get_video_fps(input_path)
+        print(f"DEBUG: Video FPS: {fps}")
         
-        extract_cmd = [
-            "ffmpeg", "-i", input_path,
-            "-vf", f"select='{select_expr}',scale=iw*{upscale_factor}:ih*{upscale_factor}",
-            "-vsync", "0",
-            "-pix_fmt", "rgb24",
-            "-start_number", "0",
-            os.path.join(temp_dir, "frame_%05d.png"),
-            "-y"
-        ]
-        # print(f"DEBUG: Extract command: {extract_cmd}")
-        extract_result = subprocess.run(extract_cmd, check=True, capture_output=True)
+        extracted_frames_count = 0
+        
+        for i, frame_idx in enumerate(random_frames):
+            timestamp = frame_idx / fps
+            frame_output = os.path.join(temp_dir, f"frame_{i:05d}.png")
+            
+            # Construct fast seek command
+            # -ss before -i is fast seek (keyframe spacing)
+            # -vsync 0 prevents frame duplication/drop logic messing with single frame extraction
+            extract_cmd = [
+                "ffmpeg", 
+                "-ss", f"{timestamp:.6f}",
+                "-i", input_path,
+                "-vf", f"scale=iw*{upscale_factor}:ih*{upscale_factor}",
+                "-frames:v", "1",
+                "-vsync", "0",
+                "-pix_fmt", "rgb24",
+                frame_output,
+                "-y"
+            ]
+            
+            # print(f"DEBUG: Extracting frame {frame_idx} at {timestamp:.6f}s")
+            try:
+                subprocess.run(
+                    extract_cmd, 
+                    check=True, 
+                    capture_output=True
+                )
+                if os.path.exists(frame_output):
+                    extracted_frames_count += 1
+            except subprocess.CalledProcessError as e:
+                print(f"Warning: Failed to extract frame {frame_idx} at {timestamp}s: {e}")
+                # We continue to try other frames even if one fails
         
         # Check if frames were actually generated
-        generated_files = os.listdir(temp_dir)
+        generated_files = sorted(os.listdir(temp_dir))
         if not generated_files:
-            # If no frames extracted, this is likely an index out of bounds error vs the video length
-            # We will try to get the frame count for a better error message
-            try:
-                probe_cmd = ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=nb_frames", "-of", "default=noprint_wrappers=1:nokey=1", input_path]
-                nb_frames = subprocess.check_output(probe_cmd).decode().strip()
-                print(f"ERROR: Video has {nb_frames} frames, but requested indices were: {random_frames}")
-            except:
-                pass
-                
             print("ERROR: No frames were extracted!")
-            print(f"Extraction Stdout: {extract_result.stdout.decode(errors='ignore')}")
-            print(f"Extraction Stderr: {extract_result.stderr.decode(errors='ignore')}")
             raise RuntimeError("FFmpeg extraction produced no frames.")
         
-        # print(f"DEBUG: Extracted {len(generated_files)} frames.")
+        print(f"DEBUG: Extracted {len(generated_files)} frames using seek.")
 
         # 2. Re-assemble PNGs into a Y4M
         # We use '-f image2' to read the sequential images as a video stream

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -61,7 +61,9 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     try:
         # 1. Extract specific frames as high-quality PNGs
         # We use -start_number 0 to ensure sequential naming for the next step
-        select_expr = "+".join([f"eq(n\\,{f})" for f in random_frames])
+        print(f"DEBUG: random_frames: {random_frames}")
+        select_expr = "+".join([f"eq(n,{f})" for f in random_frames])
+        print(f"DEBUG: select_expr: {select_expr}")
         
         extract_cmd = [
             "ffmpeg", "-i", input_path,
@@ -72,7 +74,18 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
             os.path.join(temp_dir, "frame_%05d.png"),
             "-y"
         ]
-        subprocess.run(extract_cmd, check=True, capture_output=True)
+        print(f"DEBUG: Extract command: {extract_cmd}")
+        extract_result = subprocess.run(extract_cmd, check=True, capture_output=True)
+        
+        # Check if frames were actually generated
+        generated_files = os.listdir(temp_dir)
+        if not generated_files:
+            print("ERROR: No frames were extracted!")
+            print(f"Extraction Stdout: {extract_result.stdout.decode(errors='ignore')}")
+            print(f"Extraction Stderr: {extract_result.stderr.decode(errors='ignore')}")
+            raise RuntimeError("FFmpeg extraction produced no frames.")
+        
+        print(f"DEBUG: Extracted {len(generated_files)} frames.")
 
         # 2. Re-assemble PNGs into a Y4M
         # We use '-f image2' to read the sequential images as a video stream

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -61,18 +61,15 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     try:
         # 1. Extract specific frames as high-quality PNGs
         # We use -start_number 0 to ensure sequential naming for the next step
-        # Since we're dealing with potentially VFR (Variable Frame Rate) clips that might have
-        # fewer frames than the reference, we can't reliably select specific frame indices
-        # that were calculated from the reference clip.
-        # Instead, we'll extract the first N frames, where N is the sample count.
+        print(f"DEBUG: random_frames: {random_frames}")
         
-        num_frames_to_extract = len(random_frames)
-        print(f"DEBUG: Extracting first {num_frames_to_extract} frames sequentially.")
+        # Use simple eq(n,f) without extra escaping
+        select_expr = "+".join([f"eq(n,{f})" for f in random_frames])
+        print(f"DEBUG: select_expr: {select_expr}")
         
         extract_cmd = [
             "ffmpeg", "-i", input_path,
-            "-vf", f"scale=iw*{upscale_factor}:ih*{upscale_factor}",
-            "-vframes", str(num_frames_to_extract),
+            "-vf", f"select='{select_expr}',scale=iw*{upscale_factor}:ih*{upscale_factor}",
             "-vsync", "0",
             "-pix_fmt", "rgb24",
             "-start_number", "0",

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -52,37 +52,31 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     if not input_path.lower().endswith(".mp4"):
         raise ValueError("Input file must be an MP4 file.")
 
-    # Change extension to .y4m and keep it in the same directory
     output_path = os.path.splitext(input_path)[0] + ".y4m"
+    select_expr = "+".join([f"eq(n\\,{f})" for f in random_frames])
+
+    # Build the filter chain
+    # 1. select the frames
+    # 2. setpts=N/TB: Resets timestamps to be sequential indices (0, 1, 2...)
+    #    This ignores the "240fps" buggy container timing.
+    # 3. scale: if needed
+    vf_filters = [f"select='{select_expr}'", "setpts=N/TB"]
+    
+    if upscale_factor >= 2:
+        vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
+
+    filter_string = ",".join(vf_filters)
 
     try:
-        select_expr = "+".join([f"eq(n\\,{f})" for f in random_frames])
-        
-        if upscale_factor >= 2:
-
-            scale_width = f"iw*{upscale_factor}"
-            scale_height = f"ih*{upscale_factor}"
-
-            subprocess.run([
-                "ffmpeg",
-                "-i", input_path,
-                "-vf", f"select='{select_expr}',scale={scale_width}:{scale_height}",
-                "-pix_fmt", "yuv420p",
-                "-vsync", "vfr",
-                output_path,
-                "-y"
-            ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-
-        else:
-            subprocess.run([
-                "ffmpeg",
-                "-i", input_path,
-                "-vf", f"select='{select_expr}'",
-                "-pix_fmt", "yuv420p",
-                "-vsync", "vfr",
-                output_path,
-                "-y"
-            ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        subprocess.run([
+            "ffmpeg",
+            "-i", input_path,
+            "-vf", filter_string,
+            "-pix_fmt", "yuv420p",
+            "-vsync", "0", 
+            output_path,
+            "-y"
+        ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
         return output_path
 

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -68,10 +68,11 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
             "-vf", f"select='{select_expr}',scale=iw*{upscale_factor}:ih*{upscale_factor}",
             "-vsync", "0",
             "-pix_fmt", "rgb24",
+            "-start_number", "0",
             os.path.join(temp_dir, "frame_%05d.png"),
             "-y"
         ]
-        subprocess.run(extract_cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        subprocess.run(extract_cmd, check=True, capture_output=True)
 
         # 2. Re-assemble PNGs into a Y4M
         # We use '-f image2' to read the sequential images as a video stream
@@ -83,10 +84,25 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
             output_path,
             "-y"
         ]
-        subprocess.run(assemble_cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        subprocess.run(assemble_cmd, check=True, capture_output=True)
 
         return output_path
 
+    except subprocess.CalledProcessError as e:
+        print(f"FFmpeg command failed with exit code {e.returncode}")
+        print(f"Command: {e.cmd}")
+        if e.stdout:
+            print(f"Stdout: {e.stdout.decode(errors='ignore')}")
+        if e.stderr:
+            print(f"Stderr: {e.stderr.decode(errors='ignore')}")
+        
+        # List contents of temp directory to check if frames were generated
+        if os.path.exists(temp_dir):
+            print(f"Contents of {temp_dir}: {os.listdir(temp_dir)}")
+        else:
+            print(f"Temp dir {temp_dir} does not exist.")
+            
+        raise
     except Exception as e:
         print(f"Nuclear extraction failed: {e}")
         raise

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -60,28 +60,20 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     # 2. setpts=N/TB: Resets timestamps to be sequential indices (0, 1, 2...)
     #    This ignores the "240fps" buggy container timing.
     # 3. scale: if needed
-    # vf_filters = [f"select='{select_expr}'", "setpts=N/TB"]
+    vf_filters = [f"select='{select_expr}'", "setpts=N/TB"]
     
-    # if upscale_factor >= 2:
-    #     vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
+    if upscale_factor >= 2:
+        vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
 
-    # filter_string = ",".join(vf_filters)
+    filter_string = ",".join(vf_filters)
 
     try:
         subprocess.run([
             "ffmpeg",
-            # 1. Force the decoder to ignore the "broken" container FPS
-            "-bitexact", 
             "-i", input_path,
-            "-vf", (
-                f"select='{select_expr}'," # Select the frames
-                "setpts=N/TB,"             # Reset timestamps to be sequential
-                f"scale=iw*{upscale_factor}:ih*{upscale_factor}," # Scale if needed
-                "format=yuv420p"           # Ensure pixel format inside filtergraph
-            ),
+            "-vf", filter_string,
             "-pix_fmt", "yuv420p",
-            "-vsync", "passthrough",       # Stop FFmpeg from trying to "fix" the timing
-            "-an",                         # Drop audio to prevent sync-based dropping
+            "-vsync", "0", 
             output_path,
             "-y"
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -60,20 +60,28 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     # 2. setpts=N/TB: Resets timestamps to be sequential indices (0, 1, 2...)
     #    This ignores the "240fps" buggy container timing.
     # 3. scale: if needed
-    vf_filters = [f"select='{select_expr}'", "setpts=N/TB"]
+    # vf_filters = [f"select='{select_expr}'", "setpts=N/TB"]
     
-    if upscale_factor >= 2:
-        vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
+    # if upscale_factor >= 2:
+    #     vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
 
     filter_string = ",".join(vf_filters)
 
     try:
         subprocess.run([
             "ffmpeg",
+            # 1. Force the decoder to ignore the "broken" container FPS
+            "-bitexact", 
             "-i", input_path,
-            "-vf", filter_string,
+            "-vf", (
+                f"select='{select_expr}'," # Select the frames
+                "setpts=N/TB,"             # Reset timestamps to be sequential
+                f"scale=iw*{upscale_factor}:ih*{upscale_factor}," # Scale if needed
+                "format=yuv420p"           # Ensure pixel format inside filtergraph
+            ),
             "-pix_fmt", "yuv420p",
-            "-vsync", "0", 
+            "-vsync", "passthrough",       # Stop FFmpeg from trying to "fix" the timing
+            "-an",                         # Drop audio to prevent sync-based dropping
             output_path,
             "-y"
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -61,13 +61,18 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     try:
         # 1. Extract specific frames as high-quality PNGs
         # We use -start_number 0 to ensure sequential naming for the next step
-        print(f"DEBUG: random_frames: {random_frames}")
-        select_expr = "+".join([f"eq(n,{f})" for f in random_frames])
-        print(f"DEBUG: select_expr: {select_expr}")
+        # Since we're dealing with potentially VFR (Variable Frame Rate) clips that might have
+        # fewer frames than the reference, we can't reliably select specific frame indices
+        # that were calculated from the reference clip.
+        # Instead, we'll extract the first N frames, where N is the sample count.
+        
+        num_frames_to_extract = len(random_frames)
+        print(f"DEBUG: Extracting first {num_frames_to_extract} frames sequentially.")
         
         extract_cmd = [
             "ffmpeg", "-i", input_path,
-            "-vf", f"select='{select_expr}',scale=iw*{upscale_factor}:ih*{upscale_factor}",
+            "-vf", f"scale=iw*{upscale_factor}:ih*{upscale_factor}",
+            "-vframes", str(num_frames_to_extract),
             "-vsync", "0",
             "-pix_fmt", "rgb24",
             "-start_number", "0",

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -60,20 +60,28 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     # 2. setpts=N/TB: Resets timestamps to be sequential indices (0, 1, 2...)
     #    This ignores the "240fps" buggy container timing.
     # 3. scale: if needed
-    vf_filters = [f"select='{select_expr}'", "setpts=N/TB"]
+    # vf_filters = [f"select='{select_expr}'", "setpts=N/TB"]
     
-    if upscale_factor >= 2:
-        vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
+    # if upscale_factor >= 2:
+    #     vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
 
-    filter_string = ",".join(vf_filters)
+    # filter_string = ",".join(vf_filters)
 
     try:
         subprocess.run([
             "ffmpeg",
+            # 1. Force the decoder to ignore the "broken" container FPS
+            "-bitexact", 
             "-i", input_path,
-            "-vf", filter_string,
+            "-vf", (
+                f"select='{select_expr}'," # Select the frames
+                "setpts=N/TB,"             # Reset timestamps to be sequential
+                f"scale=iw*{upscale_factor}:ih*{upscale_factor}," # Scale if needed
+                "format=yuv420p"           # Ensure pixel format inside filtergraph
+            ),
             "-pix_fmt", "yuv420p",
-            "-vsync", "0", 
+            "-vsync", "passthrough",       # Stop FFmpeg from trying to "fix" the timing
+            "-an",                         # Drop audio to prevent sync-based dropping
             output_path,
             "-y"
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -3,6 +3,8 @@ import xml.etree.ElementTree as ET
 import os
 from moviepy.editor import VideoFileClip
 from loguru import logger
+import tempfile
+import shutil
 
 def trim_video(video_path, start_time, trim_duration=1):
     """
@@ -53,44 +55,44 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
         raise ValueError("Input file must be an MP4 file.")
 
     output_path = os.path.splitext(input_path)[0] + ".y4m"
-    select_expr = "+".join([f"eq(n\\,{f})" for f in random_frames])
-
-    # Build the filter chain
-    # 1. select the frames
-    # 2. setpts=N/TB: Resets timestamps to be sequential indices (0, 1, 2...)
-    #    This ignores the "240fps" buggy container timing.
-    # 3. scale: if needed
-    # vf_filters = [f"select='{select_expr}'", "setpts=N/TB"]
     
-    # if upscale_factor >= 2:
-    #     vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
-
-    # filter_string = ",".join(vf_filters)
-
+    temp_dir = tempfile.mkdtemp()
+    
     try:
-        subprocess.run([
+        # 1. Extract specific frames as high-quality PNGs
+        # We use -start_number 0 to ensure sequential naming for the next step
+        select_expr = "+".join([f"eq(n\\,{f})" for f in random_frames])
+        
+        extract_cmd = [
+            "ffmpeg", "-i", input_path,
+            "-vf", f"select='{select_expr}',scale=iw*{upscale_factor}:ih*{upscale_factor}",
+            "-vsync", "0",
+            "-pix_fmt", "rgb24",
+            os.path.join(temp_dir, "frame_%05d.png"),
+            "-y"
+        ]
+        subprocess.run(extract_cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+
+        # 2. Re-assemble PNGs into a Y4M
+        # We use '-f image2' to read the sequential images as a video stream
+        assemble_cmd = [
             "ffmpeg",
-            # 1. Force the decoder to ignore the "broken" container FPS
-            "-bitexact", 
-            "-i", input_path,
-            "-vf", (
-                f"select='{select_expr}'," # Select the frames
-                "setpts=N/TB,"             # Reset timestamps to be sequential
-                f"scale=iw*{upscale_factor}:ih*{upscale_factor}," # Scale if needed
-                "format=yuv420p"           # Ensure pixel format inside filtergraph
-            ),
-            "-pix_fmt", "yuv420p",
-            "-vsync", "passthrough",       # Stop FFmpeg from trying to "fix" the timing
-            "-an",                         # Drop audio to prevent sync-based dropping
+            "-framerate", "30", # We set a 'sane' rate for the Y4M header
+            "-i", os.path.join(temp_dir, "frame_%05d.png"),
+            "-pix_fmt", "yuv420p", # Convert back to target pix_fmt
             output_path,
             "-y"
-        ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        ]
+        subprocess.run(assemble_cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
         return output_path
 
     except Exception as e:
-        print(f"Error in vmaf_metric_batch: {e}")
+        print(f"Nuclear extraction failed: {e}")
         raise
+    finally:
+        # Cleanup the image bridge
+        shutil.rmtree(temp_dir)
 
 
 def vmaf_metric(ref_path, dist_path, output_file="vmaf_output.xml", neg_model=False):

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -61,11 +61,11 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     try:
         # 1. Extract specific frames as high-quality PNGs
         # We use -start_number 0 to ensure sequential naming for the next step
-        print(f"DEBUG: random_frames: {random_frames}")
+        # print(f"DEBUG: random_frames: {random_frames}")
         
         # Use simple eq(n,f) without extra escaping
         select_expr = "+".join([f"eq(n,{f})" for f in random_frames])
-        print(f"DEBUG: select_expr: {select_expr}")
+        # print(f"DEBUG: select_expr: {select_expr}")
         
         extract_cmd = [
             "ffmpeg", "-i", input_path,
@@ -76,18 +76,27 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
             os.path.join(temp_dir, "frame_%05d.png"),
             "-y"
         ]
-        print(f"DEBUG: Extract command: {extract_cmd}")
+        # print(f"DEBUG: Extract command: {extract_cmd}")
         extract_result = subprocess.run(extract_cmd, check=True, capture_output=True)
         
         # Check if frames were actually generated
         generated_files = os.listdir(temp_dir)
         if not generated_files:
+            # If no frames extracted, this is likely an index out of bounds error vs the video length
+            # We will try to get the frame count for a better error message
+            try:
+                probe_cmd = ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=nb_frames", "-of", "default=noprint_wrappers=1:nokey=1", input_path]
+                nb_frames = subprocess.check_output(probe_cmd).decode().strip()
+                print(f"ERROR: Video has {nb_frames} frames, but requested indices were: {random_frames}")
+            except:
+                pass
+                
             print("ERROR: No frames were extracted!")
             print(f"Extraction Stdout: {extract_result.stdout.decode(errors='ignore')}")
             print(f"Extraction Stderr: {extract_result.stderr.decode(errors='ignore')}")
             raise RuntimeError("FFmpeg extraction produced no frames.")
         
-        print(f"DEBUG: Extracted {len(generated_files)} frames.")
+        # print(f"DEBUG: Extracted {len(generated_files)} frames.")
 
         # 2. Re-assemble PNGs into a Y4M
         # We use '-f image2' to read the sequential images as a video stream

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -65,7 +65,7 @@ def convert_mp4_to_y4m(input_path, random_frames, upscale_factor=1):
     # if upscale_factor >= 2:
     #     vf_filters.append(f"scale=iw*{upscale_factor}:ih*{upscale_factor}")
 
-    filter_string = ",".join(vf_filters)
+    # filter_string = ",".join(vf_filters)
 
     try:
         subprocess.run([

--- a/vidaio_subnet_core/__init__.py
+++ b/vidaio_subnet_core/__init__.py
@@ -12,7 +12,7 @@ __all__ = [
     "CONFIG",
 ]
 
-__version__ = "2.1.27"
+__version__ = "2.1.28"
 
 version_split = __version__.split(".")
 __spec_version__ = (


### PR DESCRIPTION
- switch to `avg_frame_rate` metadata instead of `r_frame_rate` for input with buggy values such as 240 fps causing scoring bugs
- modify y4m extraction to use fast seek and scale to longer videos (so that `trim_video` does not have to be used)
- `VMAF_SAMPLE_COUNT` corner case handled in y4m extraction