### PR TITLE
VMAF & color/chroma validation with ffmpeg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ IQA-PyTorch/
 MDTVSFA/
 output/
 ignore/
+scoring.md
 MANIQA/
 frames/
 tmp/

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -euo pipefail
+
+# run this script using `sudo -E ./bootstrap.sh`, otherwise it won't work
+#
+# If you're seeing issues with `dpkg` on platforms like tensordock, wait 15
+# minutes and try running the script again.
+#
+# Once installed to see the autoupdater logs, run 
+# `sudo journalctl -fu vision-autoupdater`
+################################################################################
+
+# external vars the user may override
+################################################################################
+WITH_AUTOUPDATES=${WITH_AUTOUPDATES:-1}
+NVIDIA_DRIVER_VERSION=${NVIDIA_DRIVER_VERSION:-535}
+NO_LAUNCH=${NO_LAUNCH:-0}
+
+# internal vars
+################################################################################
+REBOOT_REQUIRED=0
+export DEBIAN_FRONTEND=noninteractive
+
+function echo_() {
+  echo "# $@"
+  echo "################################################################################"
+}
+
+# check for root and setup exit trap
+################################################################################
+if [[ $(id -u) -ne 0 ]]; then
+  echo_ "Please run this script as root."
+  exit 1
+fi
+
+function on_exit_ {
+  echo_ cleaning up...
+  apt-mark unhold openssh-server
+}
+trap on_exit_ INT TERM EXIT
+
+# setup base files/folders
+################################################################################
+echo_ setting up base files and folders
+touch $HOME/.bashrc
+chown $SUDO_USER:$SUDO_USER $HOME/.bashrc
+chmod 644 $HOME/.bashrc
+
+mkdir -p $HOME/.local/bin
+if ! [[ $(echo $PATH | grep "$HOME/.local/bin") ]]; then
+  echo '' >> $HOME/.bashrc
+  echo 'export PATH=$HOME/.local/bin:$PATH' >> $HOME/.bashrc
+fi
+chown -R $SUDO_USER:$SUDO_USER $HOME/.local
+
+# do not upgrade openssh server whilst installing
+################################################################################
+apt-mark hold openssh-server
+
+# fix anything broken, update stuff, and install base software
+################################################################################
+echo_ setting up base packages
+apt update -qq
+apt install -y vim git curl wget cron net-tools dnsutils software-properties-common
+
+# docker
+################################################################################
+echo_ checking for docker
+if ! [[ $(which docker) ]]; then
+  echo_ docker was not found, installing...
+  apt update -qq
+  apt install -y docker.io
+  systemctl enable --now docker
+fi
+
+groupadd docker || true
+usermod -aG docker $SUDO_USER || true
+
+# nvidia drivers
+################################################################################
+echo_ checking for nvidia drivers
+if ! [[ $(which nvidia-smi) ]]; then
+  echo_ nvidia drivers were not found, installing...
+
+  apt purge nvidia-*
+  add-apt-repository -y ppa:graphics-drivers/ppa
+  apt update -qq
+  apt-mark unhold nvidia* libnvidia*
+  apt install -y libnvidia-common-$NVIDIA_DRIVER_VERSION libnvidia-gl-$NVIDIA_DRIVER_VERSION nvidia-driver-$NVIDIA_DRIVER_VERSION
+  dpkg-query -W --showformat='${Package} ${Status}\n' | grep -v deinstall | awk '{ print $1 }' | grep -E 'nvidia.*-[0-9]+$' | xargs -r -L 1 apt-mark hold
+
+  # signal to the script that it _should_ reboot the server once done.
+  REBOOT_REQUIRED=1
+fi
+
+# nvidia/cuda/container-toolkit
+################################################################################
+echo_ checking for the nvidia container toolkit
+if ! [[ $(command nvidia-ctk) ]]; then
+  echo_ the nvidia container toolkit was not found, installing...
+  wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
+  dpkg -i cuda-keyring_1.1-1_all.deb
+  rm cuda-keyring_1.1-1_all.deb
+
+  apt update -qq
+  apt-mark unhold nvidia* libnvidia*
+  apt install -y nvidia-container-toolkit
+  dpkg-query -W --showformat='${Package} ${Status}\n' | grep -v deinstall | awk '{ print $1 }' | grep -E 'nvidia.*-[0-9]+$' | xargs -r -L 1 apt-mark hold
+fi
+
+nvidia-ctk runtime configure --runtime=docker
+systemctl restart docker
+
+# python 3.11
+################################################################################
+echo_ checking for python3.11
+if ! [[ $(which python3.11) ]]; then
+  echo_ python3.11 was not found, installing...
+  add-apt-repository -y ppa:deadsnakes/ppa
+  apt install -y python3.11-full
+  python3.11 -m ensurepip
+fi
+
+# ensure `python` and `pip` point to the right place
+rm /usr/bin/pip || true
+echo '#!/bin/bash' >> /usr/bin/pip
+echo 'python3.11 -m pip $@' >> /usr/bin/pip
+chmod a+x /usr/bin/pip
+
+rm /usr/bin/python || true
+ln -s $(which python3.11) /usr/bin/python
+
+# finally, reboot if needed
+################################################################################
+if [[ REBOOT_REQUIRED -eq 1 ]]; then
+  echo_ "bootstrap.sh modified something that requires a reboot. Please SSH back in to this machine after a short while :)"
+  shutdown now -r
+else
+  echo_ "bootstrap.sh is all done :)"
+fi

--- a/docs/validator_setup.md
+++ b/docs/validator_setup.md
@@ -12,6 +12,33 @@ To achieve optimal results, we recommend the following setup:
 
 ---
 
+## Bootstrap System Dependencies
+
+The `bootstrap.sh` script at the repository root automates the installation of core system-level dependencies:
+
+- **NVIDIA GPU drivers** (default version 535)
+- **Docker** and the **NVIDIA Container Toolkit**
+- **Python 3.11**
+- Base utilities (git, curl, wget, etc.)
+
+Run the script **as root** with the `-E` flag to preserve environment variables:
+
+```bash
+sudo -E ./bootstrap.sh
+```
+
+> **Note:** If you encounter `dpkg` lock issues (common on platforms like TensorDock), wait ~15 minutes and re-run the script. The script will **automatically reboot** the machine if a new NVIDIA driver was installed.
+
+#### Optional environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NVIDIA_DRIVER_VERSION` | `535` | NVIDIA driver version to install |
+
+Once the bootstrap completes (and any reboot finishes), proceed with the rest of this guide.
+
+---
+
 ## Install PM2 (Process Manager)
 
 **PM2** is used to manage and monitor the validator process. If you haven’t installed PM2 yet, follow these steps:

--- a/docs/validator_setup.md
+++ b/docs/validator_setup.md
@@ -151,104 +151,19 @@ To enable video quality validation, install **VMAF** by following the steps belo
 
 ---
 
-Clone the VMAF repository into the working root directory of your `vidaio-subnet` package. If the `vidaio-subnet` virtual environment is currently active, deactivate it first:
+Clone the VMAF repository into the working root directory of your `vidaio-subnet` package:
 
 ```bash
 git clone https://github.com/vidAio-subnet/vmaf.git
+cp vmaf_utils/Dockerfile vmaf/Dockerfile
+cp vmaf_utils/Dockerfile.ffmpeg vmaf/Dockerfile.ffmpeg
 cd vmaf
+git stash && git reset --hard 332dde62838d91d8b5216e9822de58851f2fd64f && git stash apply
+docker build -t vmaf .
+docker build -t vmaf_ffmpeg:latest -f Dockerfile.ffmpeg .
 ```
 
 ---
-
-### Step 1: Set Up a Virtual Environment in VMAF directory
-
-1. Install `venv` if it’s not already installed:
-   ```bash
-   python3 -m venv vmaf-venv
-   ```
-
-2. Activate the virtual environment:
-   ```bash
-   source vmaf-venv/bin/activate
-   ```
-
----
-
-### Step 2: Install Dependencies
-
-1. Install `meson`:
-   ```bash
-   pip install meson
-   ```
-
-2. Install system dependencies:
-   ```bash
-   sudo apt-get update
-   sudo apt-get install nasm ninja-build doxygen xxd
-   ```
-   For Ninja, verify whether the package name is `ninja` or `ninja-build` before running the install command.
-
----
-
-### Step 3: Compile VMAF
-
-
-1. Set up the build environment:
-   ```bash
-   cd libvmaf
-   meson setup build --buildtype release -Denable_avx512=true
-   ```
-
-2. Optional flags:
-   - Use `-Denable_float=true` to enable floating-point feature extractors.
-   - Use `-Denable_avx512=true` to enable AVX-512 SIMD instructions for faster processing on supported CPUs.  
-   - Use `-Denable_cuda=true` to build with CUDA support (requires `nvcc` and CUDA >= 11).  
-     **Note:** To enable CUDA successfully, ensure `nvcc` and the CUDA driver are installed. Refer to the [CUDA and NVCC setup guide](miner_setup.md#step-2-install-cuda-and-nvcc).
-   - Use `-Denable_nvtx=true` to enable NVTX marker support for profiling with Nsight Systems.
-   - **Recommendation:**
-   We recommend adding `-Denable_avx512=true` to enhance validation speed. If CUDA is available, include the flag `-Denable_cuda=true` But At present, VMAF does not include support for CUDA integration.
-
-3. Build the project:
-   ```bash
-   ninja -vC build
-   ```
-
----
-
-### Step 4: Test the Build
-
-Run tests to verify the build:
-```bash
-ninja -vC build test
-```
-
----
-
-### Step 5: Install VMAF
-
-Install the library, headers, and the command-line tool:
-```bash
-ninja -vC build install
-```
-
----
-
-### Step 6: Generate Documentation
-
-Generate HTML documentation:
-```bash
-ninja -vC build doc/html
-```
-
-### Step 7: Deactivate vmaf-venv, activate project venv
-
-```bash
-deactivate
-cd ..
-cd ..
-source venv/bin/activate
-```
-
 ## Running the Validator with PM2
 
 To run the validator, use the following command:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -589,15 +589,16 @@ class Validator(base.BaseValidator):
                     logger.warning(f"⚠️ Reference video file missing for video_id {video_id}: {reference_video_path}")
                 reference_video_paths.append(reference_video_path)
             
-            asyncio.create_task(self.score_compressions(uids, responses, payload_urls, reference_video_paths, timestamp, video_ids, uploaded_object_names, vmaf_thresholds, target_codec, codec_mode, target_bitrate, round_id))
-
+            # asyncio.create_task(self.score_compressions(uids, responses, payload_urls, reference_video_paths, timestamp, video_ids, uploaded_object_names, vmaf_thresholds, target_codec, codec_mode, target_bitrate, round_id))
+            await self.score_compressions(uids, responses, payload_urls, reference_video_paths, timestamp, video_ids, uploaded_object_names, vmaf_thresholds, target_codec, codec_mode, target_bitrate, round_id)
+            
             batch_processed_time = time.time() - batch_start_time
-            sleep_time = random.uniform(SLEEP_TIME_LOW, SLEEP_TIME_HIGH) - batch_processed_time
+            # sleep_time = random.uniform(SLEEP_TIME_LOW, SLEEP_TIME_HIGH) - batch_processed_time
 
             logger.info(f"Completed compression batch within {batch_processed_time:.2f} seconds")
-            logger.info(f"Sleeping for 5-6 minutes before next compression batch")
+            # logger.info(f"Sleeping for 5-6 minutes before next compression batch")
             
-            await asyncio.sleep(sleep_time)
+            # await asyncio.sleep(sleep_time)
 
 
     async def start_organic_loop(self):

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -618,8 +618,9 @@ def _get_signalstats(video_path, n_subsample=1, start_time=None, duration=None, 
     for line in result.stderr.split('\n'):
         line = line.strip()
 
-        # New frame boundary: "frame:N ..." line
-        if line.startswith('frame:'):
+        # New frame boundary: "[Parsed_metadata_1 @ 0x...] frame:N pts:M ..."
+        # Lines are prefixed by FFmpeg, so we can't use startswith('frame:')
+        if 'frame:' in line and 'pts:' in line:
             # Save the previous frame if it has the keys we need
             if current_frame and 'SATAVG' in current_frame and 'YAVG' in current_frame:
                 frames.append(current_frame)

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -1824,29 +1824,29 @@ async def score_upscaling_synthetics(request: UpscalingScoringRequest) -> Upscal
                 continue
 
             # Calculate VMAF — Docker-first with Y4M fallback
-            ref_clip_vmaf_path = None
-            dist_clip_vmaf_path = None
+            # ref_clip_vmaf_path = None
+            # dist_clip_vmaf_path = None
             try:
                 vmaf_start = time.time()
 
                 # Trim 1-second clips for VMAF calculation (frame-accurate)
                 ref_fps = get_video_fps(ref_path) or 30.0
-                vmaf_num_frames = int(ref_fps)  # 1 second worth of frames
-                max_start_frame = max(0, ref_total_frames - vmaf_num_frames)
-                vmaf_start_frame = random.randint(0, max_start_frame)
+                # vmaf_num_frames = int(ref_fps)  # 1 second worth of frames
+                # max_start_frame = max(0, ref_total_frames - vmaf_num_frames)
+                # vmaf_start_frame = random.randint(0, max_start_frame)
 
-                ref_clip_vmaf_path = trim_video_select(ref_path, vmaf_start_frame, vmaf_num_frames)
-                dist_clip_vmaf_path = trim_video_select(dist_path, vmaf_start_frame, vmaf_num_frames)
-                logger.info(f"Trimmed {vmaf_num_frames} frames starting at frame {vmaf_start_frame} for VMAF calculation")
+                # ref_clip_vmaf_path = trim_video_select(ref_path, vmaf_start_frame, vmaf_num_frames)
+                # dist_clip_vmaf_path = trim_video_select(dist_path, vmaf_start_frame, vmaf_num_frames)
+                # logger.info(f"Trimmed {vmaf_num_frames} frames starting at frame {vmaf_start_frame} for VMAF calculation")
 
-                if VMAF_FFMPEG_AVAILABLE and ref_clip_vmaf_path and dist_clip_vmaf_path:
+                if VMAF_FFMPEG_AVAILABLE:
                     try:
                         logger.info("Attempting Docker-based VMAF calculation (libvmaf_cuda)...")
                         vmaf_score = vmaf_metric_ffmpeg(
-                            dist_path=dist_clip_vmaf_path,
-                            ref_path=ref_clip_vmaf_path,
-                            skip_frames=0,
-                            n_subsample=1,
+                            dist_path=dist_path,
+                            ref_path=ref_path,
+                            skip_frames=np.random.randint(0, ref_fps),
+                            n_subsample=np.random.randint(20, 30),
                         )
                         logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
                     except Exception as docker_err:
@@ -1882,11 +1882,12 @@ async def score_upscaling_synthetics(request: UpscalingScoringRequest) -> Upscal
                 logger.error(f"Error calculating VMAF score: {e}")
                 continue
             finally:
+                pass
                 # Clean up trimmed VMAF clips
-                if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
-                    os.unlink(ref_clip_vmaf_path)
-                if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
-                    os.unlink(dist_clip_vmaf_path)
+                # if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
+                #     os.unlink(ref_clip_vmaf_path)
+                # if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
+                #     os.unlink(dist_clip_vmaf_path)
 
             if vmaf_score / 100 < VMAF_THRESHOLD:
                 logger.info(f"VMAF score is too low, giving zero score, current VMAF score: {vmaf_score}")
@@ -2167,8 +2168,8 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
             # Calculate VMAF — Docker-first with Y4M fallback
             # Docker path: FFmpeg signalstats for color/chroma validation (no Y4M needed)
             # Fallback path: Y4M-based VMAF + Y4M-based color/chroma validation
-            ref_clip_vmaf_path = None
-            dist_clip_vmaf_path = None
+            # ref_clip_vmaf_path = None
+            # dist_clip_vmaf_path = None
             dist_y4m_path = None
             used_docker_vmaf = False
             try:
@@ -2181,18 +2182,18 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                 max_start_frame = max(0, ref_total_frames - vmaf_num_frames)
                 vmaf_start_frame = random.randint(0, max_start_frame)
 
-                ref_clip_vmaf_path = trim_video_select(ref_path, vmaf_start_frame, vmaf_num_frames)
-                dist_clip_vmaf_path = trim_video_select(dist_path, vmaf_start_frame, vmaf_num_frames)
-                logger.info(f"Trimmed {vmaf_num_frames} frames starting at frame {vmaf_start_frame} for VMAF calculation")
+                # ref_clip_vmaf_path = trim_video_select(ref_path, vmaf_start_frame, vmaf_num_frames)
+                # dist_clip_vmaf_path = trim_video_select(dist_path, vmaf_start_frame, vmaf_num_frames)
+                # logger.info(f"Trimmed {vmaf_num_frames} frames starting at frame {vmaf_start_frame} for VMAF calculation")
 
-                if VMAF_FFMPEG_AVAILABLE and ref_clip_vmaf_path and dist_clip_vmaf_path:
+                if VMAF_FFMPEG_AVAILABLE:
                     try:
                         logger.info("Attempting Docker-based VMAF calculation (libvmaf_cuda)...")
                         vmaf_score = vmaf_metric_ffmpeg(
-                            dist_path=dist_clip_vmaf_path,
-                            ref_path=ref_clip_vmaf_path,
-                            skip_frames=0,
-                            n_subsample=1,
+                            dist_path=dist_path,
+                            ref_path=ref_path,
+                            skip_frames=np.random.randint(0, ref_fps_val),
+                            n_subsample=np.random.randint(20, 30),
                         )
                         logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
                         used_docker_vmaf = True
@@ -2230,11 +2231,12 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                     os.unlink(dist_y4m_path)
                 continue
             finally:
+                pass
                 # Clean up trimmed VMAF clips — signalstats runs on originals, not clips
-                if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
-                    os.unlink(ref_clip_vmaf_path)
-                if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
-                    os.unlink(dist_clip_vmaf_path)
+                # if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
+                #     os.unlink(ref_clip_vmaf_path)
+                # if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
+                #     os.unlink(dist_clip_vmaf_path)
 
             # === COLOR / CHROMA VALIDATION ===
             if used_docker_vmaf:

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -21,7 +21,7 @@ from fastapi import FastAPI, HTTPException
 import torchvision.transforms as transforms
 from pieapp_metric import calculate_pieapp_score
 from vidaio_subnet_core.utilities.storage_client import storage_client
-from vmaf_metric import calculate_vmaf, convert_mp4_to_y4m, trim_video
+from vmaf_metric import calculate_vmaf, convert_mp4_to_y4m, trim_video, vmaf_metric_ffmpeg, is_vmaf_ffmpeg_available
 from services.video_scheduler.video_utils import get_trim_video_path, delete_videos_with_fileid
 from scoring_function import calculate_compression_score
 
@@ -40,6 +40,9 @@ VMAF_THRESHOLD = CONFIG.score.vmaf_threshold
 PIEAPP_SAMPLE_COUNT = CONFIG.score.pieapp_sample_count
 PIEAPP_THRESHOLD = CONFIG.score.pieapp_threshold
 VMAF_SAMPLE_COUNT = CONFIG.score.vmaf_sample_count
+
+# Check if vmaf_ffmpeg Docker image with libvmaf_cuda is available
+VMAF_FFMPEG_AVAILABLE = is_vmaf_ffmpeg_available()
 
 class UpscalingScoringRequest(BaseModel):
     """
@@ -1517,16 +1520,6 @@ async def score_upscaling_synthetics(request: UpscalingScoringRequest) -> Upscal
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 5. Validated encoding settings ({encoding_msg}) in {step_time:.2f} seconds.")
 
-            random_frames = sorted(random.sample(range(ref_total_frames), min(ref_total_frames, VMAF_SAMPLE_COUNT)))
-            logger.info(f"Randomly selected {VMAF_SAMPLE_COUNT} frames for VMAF score: frame list: {random_frames}")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 6. Selected random frames for VMAF in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
-
-            ref_y4m_path = convert_mp4_to_y4m(ref_path, random_frames)
-            logger.info("The reference video has been successfully converted to Y4M format.")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 7. Converted reference video to Y4M in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
-
             if len(dist_url) < 10:
                 logger.info(f"Wrong dist download URL: {dist_url}. Assigning score of 0.")
                 vmaf_scores.append(0.0)
@@ -1538,14 +1531,14 @@ async def score_upscaling_synthetics(request: UpscalingScoringRequest) -> Upscal
                 continue
 
             step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 8. Validated distorted video in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+            logger.info(f"♎️ 6. Validated distorted video in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Get frame count using ffprobe (no AV1 warnings)
             dist_total_frames = get_frame_count(dist_path)
 
             logger.info(f"Distorted video has {dist_total_frames} frames.")
             step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 9. Retrieved distorted video frame count in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+            logger.info(f"♎️ 7. Retrieved distorted video frame count in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             if abs(dist_total_frames - ref_total_frames) > FRAME_TOLERANCE:
                 logger.info(
@@ -1561,15 +1554,49 @@ async def score_upscaling_synthetics(request: UpscalingScoringRequest) -> Upscal
                     os.unlink(dist_path)
                 continue
 
-            # Calculate VMAF
+            # Calculate VMAF — Docker-first with Y4M fallback
+            ref_clip_vmaf_path = None
+            dist_clip_vmaf_path = None
             try:
                 vmaf_start = time.time()
-                vmaf_score = calculate_vmaf(ref_y4m_path, dist_path, random_frames, neg_model=False)
+
+                # Trim 1-second clips for VMAF calculation
+                ref_fps = get_video_fps(ref_path) or 30.0
+                ref_duration = ref_total_frames / ref_fps
+                vmaf_clip_duration = 1  # seconds
+                max_start = max(0, ref_duration - vmaf_clip_duration)
+                vmaf_start_time = random.uniform(0, max_start)
+
+                ref_clip_vmaf_path = trim_video(ref_path, vmaf_start_time, vmaf_clip_duration)
+                dist_clip_vmaf_path = trim_video(dist_path, vmaf_start_time, vmaf_clip_duration)
+                logger.info(f"Trimmed 1s clips at {vmaf_start_time:.2f}s for VMAF calculation")
+
+                if VMAF_FFMPEG_AVAILABLE and ref_clip_vmaf_path and dist_clip_vmaf_path:
+                    try:
+                        logger.info("Attempting Docker-based VMAF calculation (libvmaf_cuda)...")
+                        vmaf_score = vmaf_metric_ffmpeg(
+                            dist_path=dist_clip_vmaf_path,
+                            ref_path=ref_clip_vmaf_path,
+                            skip_frames=0,
+                            n_subsample=1,
+                        )
+                        logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
+                    except Exception as docker_err:
+                        logger.warning(f"Docker VMAF failed, falling back to Y4M: {docker_err}")
+                        vmaf_score = None  # trigger fallback below
+
+                if not VMAF_FFMPEG_AVAILABLE or vmaf_score is None:
+                    # Fallback: Y4M-based VMAF calculation
+                    logger.info("Using Y4M-based VMAF calculation (fallback)...")
+                    random_frames = sorted(random.sample(range(ref_total_frames), min(ref_total_frames, VMAF_SAMPLE_COUNT)))
+                    ref_y4m_path = convert_mp4_to_y4m(ref_path, random_frames)
+                    vmaf_score = calculate_vmaf(ref_y4m_path, dist_path, random_frames, neg_model=False)
+
                 vmaf_calc_time = time.time() - vmaf_start
                 logger.info(f"☣️☣️ VMAF calculation took {vmaf_calc_time:.2f} seconds.")
 
                 step_time = time.time() - uid_start_time
-                logger.info(f"♎️ 10. Completed VMAF calculation in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+                logger.info(f"♎️ 8. Completed VMAF calculation in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
                 if vmaf_score is not None:
                     vmaf_scores.append(vmaf_score)
@@ -1586,6 +1613,12 @@ async def score_upscaling_synthetics(request: UpscalingScoringRequest) -> Upscal
                 reasons.append("failed to calculate VMAF score due to video dimension mismatch")
                 logger.error(f"Error calculating VMAF score: {e}")
                 continue
+            finally:
+                # Clean up trimmed VMAF clips
+                if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
+                    os.unlink(ref_clip_vmaf_path)
+                if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
+                    os.unlink(dist_clip_vmaf_path)
 
             if vmaf_score / 100 < VMAF_THRESHOLD:
                 logger.info(f"VMAF score is too low, giving zero score, current VMAF score: {vmaf_score}")
@@ -1863,22 +1896,54 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                 compression_rate = 1.0
                 logger.info("Reference file size is 0 or distorted file size >= reference, setting compression rate to 1.0")
 
-            # Sample frames for VMAF calculation
-            random_frames = sorted(random.sample(range(ref_total_frames), min(ref_total_frames, VMAF_SAMPLE_COUNT)))
-            logger.info(f"Randomly selected {VMAF_SAMPLE_COUNT} frames for VMAF score: frame list: {random_frames}")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 6. Selected random frames for VMAF in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
-
-            ref_y4m_path = convert_mp4_to_y4m(ref_path, random_frames)
-            logger.info("The reference video has been successfully converted to Y4M format.")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 7. Converted reference video to Y4M in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
-
-            # Calculate VMAF and get Y4M paths for validation
+            # Calculate VMAF — Docker-first with Y4M fallback
+            # Color/chroma validation still needs Y4M frames, generated separately
+            ref_clip_vmaf_path = None
+            dist_clip_vmaf_path = None
             dist_y4m_path = None
             try:
                 vmaf_start = time.time()
-                vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_path, random_frames, neg_model=True, return_y4m_path=True)
+                vmaf_score = None
+
+                # Trim 1-second clips for Docker VMAF
+                ref_fps_val = get_video_fps(ref_path) or 30.0
+                ref_duration = ref_total_frames / ref_fps_val
+                vmaf_clip_duration = 1  # seconds
+                max_start = max(0, ref_duration - vmaf_clip_duration)
+                vmaf_start_time = random.uniform(0, max_start)
+
+                ref_clip_vmaf_path = trim_video(ref_path, vmaf_start_time, vmaf_clip_duration)
+                dist_clip_vmaf_path = trim_video(dist_path, vmaf_start_time, vmaf_clip_duration)
+                logger.info(f"Trimmed 1s clips at {vmaf_start_time:.2f}s for VMAF calculation")
+
+                if VMAF_FFMPEG_AVAILABLE and ref_clip_vmaf_path and dist_clip_vmaf_path:
+                    try:
+                        logger.info("Attempting Docker-based VMAF calculation (libvmaf_cuda)...")
+                        vmaf_score = vmaf_metric_ffmpeg(
+                            dist_path=dist_clip_vmaf_path,
+                            ref_path=ref_clip_vmaf_path,
+                            skip_frames=0,
+                            n_subsample=1,
+                        )
+                        logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
+                    except Exception as docker_err:
+                        logger.warning(f"Docker VMAF failed, falling back to Y4M: {docker_err}")
+                        vmaf_score = None
+
+                # Y4M-based VMAF calculation is always needed for color validation
+                # and as VMAF fallback
+                random_frames = sorted(random.sample(range(ref_total_frames), min(ref_total_frames, VMAF_SAMPLE_COUNT)))
+                ref_y4m_path = convert_mp4_to_y4m(ref_path, random_frames)
+                logger.info("The reference video has been successfully converted to Y4M format.")
+
+                if vmaf_score is None:
+                    # Fallback: Y4M-based VMAF calculation
+                    logger.info("Using Y4M-based VMAF calculation (fallback)...")
+                    vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_path, random_frames, neg_model=True, return_y4m_path=True)
+                else:
+                    # Docker succeeded, but still generate dist Y4M for color validation
+                    dist_y4m_path = convert_mp4_to_y4m(dist_path, random_frames)
+
                 vmaf_calc_time = time.time() - vmaf_start
                 logger.info(f"☣️☣️ VMAF calculation took {vmaf_calc_time:.2f} seconds.")
 
@@ -1900,6 +1965,12 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                 if dist_y4m_path and os.path.exists(dist_y4m_path):
                     os.unlink(dist_y4m_path)
                 continue
+            finally:
+                # Clean up trimmed VMAF clips
+                if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
+                    os.unlink(ref_clip_vmaf_path)
+                if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
+                    os.unlink(dist_clip_vmaf_path)
             
             # Now reuse the Y4M files for color validation (no redundant conversion!)
             # Extract frames for color validation from Y4M files
@@ -2231,7 +2302,7 @@ async def score_organics_upscaling(request: OrganicsUpscalingScoringRequest) -> 
 
         # === MAIN SCORING LOGIC ===
         try:
-            # Calculate 0.5 second clip duration
+            # Calculate 0.25 second clip duration
             clip_duration = 0.25  # seconds
             
             # Calculate maximum start time to ensure we don't exceed video length
@@ -2239,13 +2310,13 @@ async def score_organics_upscaling(request: OrganicsUpscalingScoringRequest) -> 
             max_start_time = max(0, ref_duration - clip_duration)
             start_time = random.uniform(0, max_start_time)
             
-            logger.info(f"Creating 0.5-second clips starting from {start_time:.2f} seconds")
+            logger.info(f"Creating 0.25-second clips starting from {start_time:.2f} seconds")
             
-            # Create 0.5-second reference clip
+            # Create 0.25-second reference clip
             ref_clip_path = trim_video(ref_path, start_time, clip_duration)
             logger.info(f"Created reference clip: {ref_clip_path}")
             
-            # Create 0.5-second distorted clip
+            # Create 0.25-second distorted clip
             dist_clip_path = trim_video(dist_path, start_time, clip_duration)
             logger.info(f"Created distorted clip: {dist_clip_path}")
             
@@ -2263,18 +2334,31 @@ async def score_organics_upscaling(request: OrganicsUpscalingScoringRequest) -> 
             logger.info(f"Distorted ClipIQ score: {dist_clipiqa_score:.4f}")
             logger.info(f"Upscaled reference ClipIQ score: {ref_upscaled_clipiqa_score:.4f}")
             
-            # Create Y4M files for VMAF calculation
-            logger.info("Creating Y4M files for VMAF calculation...")
-            # Get the number of frames in the clips for Y4M conversion using ffprobe
-            ref_clip_frames = get_frame_count(ref_upscaled_clip_path)
-
-            random_frames = sorted(random.sample(range(ref_clip_frames), min(ref_clip_frames, VMAF_SAMPLE_COUNT)))
-            
-            ref_y4m_path = convert_mp4_to_y4m(ref_upscaled_clip_path, random_frames)
-            
-            # Calculate VMAF score
+            # Calculate VMAF — Docker-first with Y4M fallback
             logger.info("Calculating VMAF score...")
-            vmaf_score = calculate_vmaf(ref_y4m_path, dist_clip_path, random_frames, neg_model=False)
+            vmaf_score = None
+
+            if VMAF_FFMPEG_AVAILABLE and ref_upscaled_clip_path and dist_clip_path:
+                try:
+                    logger.info("Attempting Docker-based VMAF calculation (libvmaf_cuda)...")
+                    vmaf_score = vmaf_metric_ffmpeg(
+                        dist_path=dist_clip_path,
+                        ref_path=ref_upscaled_clip_path,
+                        skip_frames=0,
+                        n_subsample=1,
+                    )
+                    logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
+                except Exception as docker_err:
+                    logger.warning(f"Docker VMAF failed, falling back to Y4M: {docker_err}")
+                    vmaf_score = None
+
+            if vmaf_score is None:
+                # Fallback: Y4M-based VMAF calculation
+                logger.info("Using Y4M-based VMAF calculation (fallback)...")
+                ref_clip_frames = get_frame_count(ref_upscaled_clip_path)
+                random_frames = sorted(random.sample(range(ref_clip_frames), min(ref_clip_frames, VMAF_SAMPLE_COUNT)))
+                ref_y4m_path = convert_mp4_to_y4m(ref_upscaled_clip_path, random_frames)
+                vmaf_score = calculate_vmaf(ref_y4m_path, dist_clip_path, random_frames, neg_model=False)
             
             if vmaf_score is None:
                 vmaf_score = 0.0
@@ -2535,38 +2619,55 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
             logger.info(f"♎️ 6. Selected random start time for video chunks in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Create 0.5-second reference clip
-            # ref_clip_path = trim_video(ref_path, start_time, clip_duration)
-            ref_clip_path = ref_path
+            ref_clip_path = trim_video(ref_path, start_time, clip_duration)
             logger.info(f"Created reference clip: {ref_clip_path}")
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 7. Created reference video clip in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Create 0.5-second distorted clip
-            # dist_clip_path = trim_video(dist_path, start_time, clip_duration)
-            dist_clip_path = dist_path
+            dist_clip_path = trim_video(dist_path, start_time, clip_duration)
             logger.info(f"Created distorted clip: {dist_clip_path}")
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 8. Created distorted video clip in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
-            # Get the number of frames in the clips for Y4M conversion
-            
-            # ref_clip_frames = get_frame_count(ref_clip_path)
-            ref_clip_frames = ref_total_frames
-            logger.info(f"Reference clip has {ref_clip_frames} frames.")
-            
-            
-            # Ensure we don't sample more frames than available
-            random_frames = sorted(random.sample(range(ref_clip_frames), min(VMAF_SAMPLE_COUNT, ref_clip_frames)))
-            ref_y4m_path = convert_mp4_to_y4m(ref_clip_path, random_frames)
-            logger.info("The reference video clip has been successfully converted to Y4M format.")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 9. Converted reference video clip to Y4M in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
-
-            # Calculate VMAF on chunked videos and get Y4M paths for validation
+            # Calculate VMAF — Docker-first with Y4M fallback
+            # Color/chroma validation still needs Y4M frames, generated after VMAF
             dist_y4m_path = None
             try:
                 vmaf_start = time.time()
-                vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_clip_path, random_frames, neg_model=True, return_y4m_path=True)
+                vmaf_score = None
+
+                if VMAF_FFMPEG_AVAILABLE and ref_clip_path and dist_clip_path:
+                    try:
+                        logger.info("Attempting Docker-based VMAF calculation (libvmaf_cuda)...")
+                        vmaf_score = vmaf_metric_ffmpeg(
+                            dist_path=dist_clip_path,
+                            ref_path=ref_clip_path,
+                            skip_frames=0,
+                            n_subsample=1,
+                        )
+                        logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
+                    except Exception as docker_err:
+                        logger.warning(f"Docker VMAF failed, falling back to Y4M: {docker_err}")
+                        vmaf_score = None
+
+                # Y4M conversion is always needed for color validation
+                ref_clip_frames = get_frame_count(ref_clip_path)
+                logger.info(f"Reference clip has {ref_clip_frames} frames.")
+                random_frames = sorted(random.sample(range(ref_clip_frames), min(VMAF_SAMPLE_COUNT, ref_clip_frames)))
+                ref_y4m_path = convert_mp4_to_y4m(ref_clip_path, random_frames)
+                logger.info("The reference video clip has been successfully converted to Y4M format.")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 9. Converted reference video clip to Y4M in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+
+                if vmaf_score is None:
+                    # Fallback: Y4M-based VMAF calculation
+                    logger.info("Using Y4M-based VMAF calculation (fallback)...")
+                    vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_clip_path, random_frames, neg_model=True, return_y4m_path=True)
+                else:
+                    # Docker succeeded, but still generate dist Y4M for color validation
+                    dist_y4m_path = convert_mp4_to_y4m(dist_clip_path, random_frames)
+
                 vmaf_calc_time = time.time() - vmaf_start
                 logger.info(f"☣️☣️ VMAF calculation took {vmaf_calc_time:.2f} seconds.")
 

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -543,6 +543,210 @@ def validate_chroma_quality_on_frames(ref_frames, dist_frames, threshold=0.7):
         logger.error(f"Error validating chroma quality: {e}")
         return False, f"Error validating chroma: {str(e)}"
 
+
+def _get_signalstats(video_path):
+    """
+    Run ffmpeg signalstats filter on a video and return per-frame statistics.
+    Extracts YAVG (luma average) and SATAVG (saturation average) per frame
+    directly from the MP4 — no Y4M conversion needed.
+
+    Returns:
+        list of dicts, each with at least 'YAVG' and 'SATAVG' keys.
+    """
+    cmd = [
+        "ffmpeg",
+        "-i", video_path,
+        "-vf", "signalstats",
+        "-f", "null", "-",
+        "-hide_banner",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+
+    frames = []
+    for line in result.stderr.split('\n'):
+        if 'Parsed_signalstats' not in line:
+            continue
+        stats = {}
+        for token in line.split():
+            if ':' not in token:
+                continue
+            key, _, val = token.partition(':')
+            try:
+                stats[key] = float(val)
+            except ValueError:
+                pass
+        if 'SATAVG' in stats and 'YAVG' in stats:
+            frames.append(stats)
+
+    return frames
+
+
+def validate_color_channels_ffmpeg(
+    ref_path,
+    dist_path,
+    max_gray_ratio=0.50,
+    brightness_threshold=20.0,
+    ref_sat_threshold=6.0,
+    dist_sat_threshold=4.0,
+    min_checked_frames=3,
+):
+    """
+    FFmpeg-based color validation using signalstats SATAVG.
+    Detects grayscale conversion by comparing per-frame saturation.
+
+    Uses the same logic as validate_color_channels_on_frames:
+      - Skip dark reference frames (YAVG < brightness_threshold)
+      - Skip naturally grayscale reference frames (SATAVG < ref_sat_threshold)
+      - Count distorted frames with low saturation (SATAVG < dist_sat_threshold)
+      - Fail if too many distorted frames lost color
+
+    Args:
+        ref_path: Path to reference video (MP4)
+        dist_path: Path to distorted video (MP4)
+        max_gray_ratio: Max fraction of frames allowed with reduced color
+        brightness_threshold: Min YAVG to consider a ref frame
+        ref_sat_threshold: Min ref SATAVG to consider frame as colorful
+        dist_sat_threshold: Max dist SATAVG to classify as gray
+        min_checked_frames: Min evaluated frames for strict ratio validation
+
+    Returns:
+        tuple: (is_valid, reason)
+    """
+    try:
+        ref_stats = _get_signalstats(ref_path)
+        dist_stats = _get_signalstats(dist_path)
+
+        if not ref_stats or not dist_stats:
+            return False, "No frames available for color validation (signalstats)"
+
+        checked_frames = 0
+        low_color_frames = 0
+
+        for i, (ref_s, dist_s) in enumerate(zip(ref_stats, dist_stats)):
+            ref_yavg = ref_s.get('YAVG', 0)
+            ref_satavg = ref_s.get('SATAVG', 0)
+            dist_satavg = dist_s.get('SATAVG', 0)
+
+            # Skip very dark reference frames
+            if ref_yavg < brightness_threshold:
+                continue
+
+            # Skip naturally grayscale reference frames
+            if ref_satavg < ref_sat_threshold:
+                continue
+
+            checked_frames += 1
+
+            # Count distorted frames with very low saturation
+            if dist_satavg < dist_sat_threshold:
+                low_color_frames += 1
+                logger.debug(
+                    f"Frame {i}: reduced saturation detected "
+                    f"(ref_sat={ref_satavg:.2f}, dist_sat={dist_satavg:.2f})"
+                )
+
+        if checked_frames == 0:
+            return True, (
+                "No reference frames with sufficient color information were found; "
+                "color validation was skipped"
+            )
+
+        low_color_ratio = low_color_frames / checked_frames
+
+        logger.info(
+            "Color validation (ffmpeg) summary: "
+            f"{low_color_frames}/{checked_frames} frames with reduced saturation "
+            f"({low_color_ratio:.2%}); allowed maximum {max_gray_ratio:.2%}"
+        )
+
+        if low_color_ratio > max_gray_ratio:
+            return False, (
+                f"Color preservation failed: {low_color_ratio:.1%} of evaluated frames "
+                f"exhibit reduced saturation (>{max_gray_ratio:.0%} allowed)"
+            )
+
+        return True, (
+            f"Color preservation validated: {low_color_ratio:.1%} of evaluated frames "
+            f"exhibit reduced saturation (≤{max_gray_ratio:.0%} allowed)"
+        )
+
+    except Exception as e:
+        logger.error(f"Error during ffmpeg color validation: {e}")
+        return False, f"Error during color validation: {str(e)}"
+
+
+def validate_chroma_quality_ffmpeg(ref_path, dist_path, threshold=0.7):
+    """
+    FFmpeg-based chroma validation using signalstats SATAVG.
+    Detects partial UV channel reduction by comparing saturation energy.
+
+    Uses SATAVG² as a proxy for chroma energy (var(U) + var(V)),
+    then computes the ratio: dist_energy / ref_energy per frame.
+
+    Corner cases handled:
+      - Ref frames with near-zero saturation (naturally B&W) are skipped
+      - If all frames are low-energy, validation passes (content is valid B&W)
+
+    Args:
+        ref_path: Path to reference video (MP4)
+        dist_path: Path to distorted video (MP4)
+        threshold: Minimum acceptable chroma energy ratio (0.0-1.0)
+
+    Returns:
+        tuple: (is_valid, reason)
+    """
+    try:
+        ref_stats = _get_signalstats(ref_path)
+        dist_stats = _get_signalstats(dist_path)
+
+        if not ref_stats or not dist_stats:
+            return False, "No frames available for chroma validation (signalstats)"
+
+        if abs(len(ref_stats) - len(dist_stats)) > FRAME_TOLERANCE:
+            return False, (
+                f"Frame count mismatch between reference and distorted: "
+                f"{len(ref_stats)} vs {len(dist_stats)}"
+            )
+
+        chroma_ratios = []
+        low_energy_threshold = 1.0  # Min SATAVG to consider (filters flat/black frames)
+
+        for i, (ref_s, dist_s) in enumerate(zip(ref_stats, dist_stats)):
+            ref_satavg = ref_s.get('SATAVG', 0)
+            dist_satavg = dist_s.get('SATAVG', 0)
+
+            # Skip frames with very low saturation in reference (B&W or flat content)
+            if ref_satavg < low_energy_threshold:
+                logger.debug(f"Frame {i} has low ref saturation ({ref_satavg:.3f}), skipping")
+                continue
+
+            # Use SATAVG² as proxy for chroma energy (analogous to var(U) + var(V))
+            ref_energy = ref_satavg ** 2
+            dist_energy = dist_satavg ** 2
+            chroma_ratio = dist_energy / ref_energy
+            chroma_ratios.append(chroma_ratio)
+            logger.debug(f"Frame {i} chroma ratio: {chroma_ratio:.3f}")
+
+        if not chroma_ratios:
+            logger.info("All frames have low saturation (e.g., B&W content), skipping chroma validation")
+            return True, "Chroma validation skipped (low-saturation content)"
+
+        avg_chroma_ratio = float(np.mean(chroma_ratios))
+        logger.info(f"Average chroma quality ratio (ffmpeg): {avg_chroma_ratio:.3f}, Threshold: {threshold}")
+
+        if avg_chroma_ratio < threshold:
+            return False, (
+                f"Chroma quality too low: {avg_chroma_ratio:.3f} < {threshold} "
+                f"(UV channels reduced/degraded)"
+            )
+
+        return True, f"Chroma quality validated: {avg_chroma_ratio:.3f}"
+
+    except Exception as e:
+        logger.error(f"Error validating chroma quality (ffmpeg): {e}")
+        return False, f"Error validating chroma: {str(e)}"
+
 # Calculate ClipIQA+ inspired score
 def calculate_clipiqa_plus_score(frames):
     """Calculate ClipIQA+ inspired score for given frames"""
@@ -1897,15 +2101,17 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                 logger.info("Reference file size is 0 or distorted file size >= reference, setting compression rate to 1.0")
 
             # Calculate VMAF — Docker-first with Y4M fallback
-            # Color/chroma validation still needs Y4M frames, generated separately
+            # Docker path: FFmpeg signalstats for color/chroma validation (no Y4M needed)
+            # Fallback path: Y4M-based VMAF + Y4M-based color/chroma validation
             ref_clip_vmaf_path = None
             dist_clip_vmaf_path = None
             dist_y4m_path = None
+            used_docker_vmaf = False
             try:
                 vmaf_start = time.time()
                 vmaf_score = None
 
-                # Trim 1-second clips for Docker VMAF
+                # Trim 1-second clips for VMAF calculation
                 ref_fps_val = get_video_fps(ref_path) or 30.0
                 ref_duration = ref_total_frames / ref_fps_val
                 vmaf_clip_duration = 1  # seconds
@@ -1926,23 +2132,18 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                             n_subsample=1,
                         )
                         logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
+                        used_docker_vmaf = True
                     except Exception as docker_err:
                         logger.warning(f"Docker VMAF failed, falling back to Y4M: {docker_err}")
                         vmaf_score = None
 
-                # Y4M-based VMAF calculation is always needed for color validation
-                # and as VMAF fallback
-                random_frames = sorted(random.sample(range(ref_total_frames), min(ref_total_frames, VMAF_SAMPLE_COUNT)))
-                ref_y4m_path = convert_mp4_to_y4m(ref_path, random_frames)
-                logger.info("The reference video has been successfully converted to Y4M format.")
-
                 if vmaf_score is None:
                     # Fallback: Y4M-based VMAF calculation
                     logger.info("Using Y4M-based VMAF calculation (fallback)...")
+                    random_frames = sorted(random.sample(range(ref_total_frames), min(ref_total_frames, VMAF_SAMPLE_COUNT)))
+                    ref_y4m_path = convert_mp4_to_y4m(ref_path, random_frames)
+                    logger.info("The reference video has been successfully converted to Y4M format.")
                     vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_path, random_frames, neg_model=True, return_y4m_path=True)
-                else:
-                    # Docker succeeded, but still generate dist Y4M for color validation
-                    dist_y4m_path = convert_mp4_to_y4m(dist_path, random_frames)
 
                 vmaf_calc_time = time.time() - vmaf_start
                 logger.info(f"☣️☣️ VMAF calculation took {vmaf_calc_time:.2f} seconds.")
@@ -1966,57 +2167,95 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                     os.unlink(dist_y4m_path)
                 continue
             finally:
-                # Clean up trimmed VMAF clips
-                if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
-                    os.unlink(ref_clip_vmaf_path)
-                if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
-                    os.unlink(dist_clip_vmaf_path)
-            
-            # Now reuse the Y4M files for color validation (no redundant conversion!)
-            # Extract frames for color validation from Y4M files
-            logger.info(f"Extracting frames from Y4M for color validation (reusing VMAF Y4M files)")
-            dist_frames = extract_frames_from_y4m(dist_y4m_path)
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 8.5. Extracted {len(dist_frames)} frames from Y4M for color validation in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+                # Clean up trimmed VMAF clips only if we're NOT using them for FFmpeg validation
+                # If Docker was used, we still need the clips for signalstats validation below
+                if not used_docker_vmaf:
+                    if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
+                        os.unlink(ref_clip_vmaf_path)
+                    if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
+                        os.unlink(dist_clip_vmaf_path)
 
-            # Extract reference frames from Y4M for chroma quality comparison
-            ref_frames = extract_frames_from_y4m(ref_y4m_path)
+            # === COLOR / CHROMA VALIDATION ===
+            if used_docker_vmaf:
+                # Docker path: use FFmpeg signalstats directly on trimmed clips (no Y4M needed)
+                logger.info("Using FFmpeg signalstats for color/chroma validation (no Y4M conversion)")
 
-            # Validate color channels (grayscale check)
-            color_valid, color_reason = validate_color_channels_on_frames(ref_frames, dist_frames)
-            if not color_valid:
-                logger.error(f"UID {uid}: {color_reason}")
-                compression_rates.append(0.9999) 
-                final_scores.append(0.0)
-                reasons.append(f"Color validation failed: {color_reason}")
-                if dist_path and os.path.exists(dist_path):
-                    os.unlink(dist_path)
-                if dist_y4m_path and os.path.exists(dist_y4m_path):
-                    os.unlink(dist_y4m_path)
-                continue
-            
-            logger.info(f"✅ UID {uid}: Color channels validated - {color_reason}")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 8.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+                try:
+                    # Color validation (grayscale detection)
+                    color_valid, color_reason = validate_color_channels_ffmpeg(ref_clip_vmaf_path, dist_clip_vmaf_path)
+                    if not color_valid:
+                        logger.error(f"UID {uid}: {color_reason}")
+                        compression_rates.append(0.9999)
+                        final_scores.append(0.0)
+                        reasons.append(f"Color validation failed: {color_reason}")
+                        continue
 
-            # Validate chroma quality (prevents partial UV reduction)
-            chroma_valid, chroma_reason = validate_chroma_quality_on_frames(
-                ref_frames, dist_frames, threshold=0.7
-            )
-            if not chroma_valid:
-                logger.error(f"UID {uid}: {chroma_reason}")
-                compression_rates.append(0.9999) 
-                final_scores.append(0.0)
-                reasons.append(f"Chroma validation failed: {chroma_reason}")
-                if dist_path and os.path.exists(dist_path):
-                    os.unlink(dist_path)
-                if dist_y4m_path and os.path.exists(dist_y4m_path):
-                    os.unlink(dist_y4m_path)
-                continue
-            
-            logger.info(f"✅ UID {uid}: Chroma quality validated - {chroma_reason}")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 8.7. Validated chroma quality in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+                    logger.info(f"✅ UID {uid}: Color channels validated (ffmpeg) - {color_reason}")
+                    step_time = time.time() - uid_start_time
+                    logger.info(f"♎️ 8.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+
+                    # Chroma validation (UV reduction detection)
+                    chroma_valid, chroma_reason = validate_chroma_quality_ffmpeg(ref_clip_vmaf_path, dist_clip_vmaf_path, threshold=0.7)
+                    if not chroma_valid:
+                        logger.error(f"UID {uid}: {chroma_reason}")
+                        compression_rates.append(0.9999)
+                        final_scores.append(0.0)
+                        reasons.append(f"Chroma validation failed: {chroma_reason}")
+                        continue
+
+                    logger.info(f"✅ UID {uid}: Chroma quality validated (ffmpeg) - {chroma_reason}")
+                    step_time = time.time() - uid_start_time
+                    logger.info(f"♎️ 8.7. Validated chroma quality in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+                finally:
+                    # Clean up trimmed clips after FFmpeg validation
+                    if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
+                        os.unlink(ref_clip_vmaf_path)
+                    if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
+                        os.unlink(dist_clip_vmaf_path)
+            else:
+                # Fallback path: use Y4M-based validation (existing approach)
+                logger.info("Extracting frames from Y4M for color validation (reusing VMAF Y4M files)")
+                dist_frames = extract_frames_from_y4m(dist_y4m_path)
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 8.5. Extracted {len(dist_frames)} frames from Y4M for color validation in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+
+                ref_frames = extract_frames_from_y4m(ref_y4m_path)
+
+                # Validate color channels (grayscale check)
+                color_valid, color_reason = validate_color_channels_on_frames(ref_frames, dist_frames)
+                if not color_valid:
+                    logger.error(f"UID {uid}: {color_reason}")
+                    compression_rates.append(0.9999)
+                    final_scores.append(0.0)
+                    reasons.append(f"Color validation failed: {color_reason}")
+                    if dist_path and os.path.exists(dist_path):
+                        os.unlink(dist_path)
+                    if dist_y4m_path and os.path.exists(dist_y4m_path):
+                        os.unlink(dist_y4m_path)
+                    continue
+
+                logger.info(f"✅ UID {uid}: Color channels validated - {color_reason}")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 8.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+
+                # Validate chroma quality (prevents partial UV reduction)
+                chroma_valid, chroma_reason = validate_chroma_quality_on_frames(
+                    ref_frames, dist_frames, threshold=0.7
+                )
+                if not chroma_valid:
+                    logger.error(f"UID {uid}: {chroma_reason}")
+                    compression_rates.append(0.9999)
+                    final_scores.append(0.0)
+                    reasons.append(f"Chroma validation failed: {chroma_reason}")
+                    if dist_path and os.path.exists(dist_path):
+                        os.unlink(dist_path)
+                    if dist_y4m_path and os.path.exists(dist_y4m_path):
+                        os.unlink(dist_y4m_path)
+                    continue
+
+                logger.info(f"✅ UID {uid}: Chroma quality validated - {chroma_reason}")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 8.7. Validated chroma quality in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Calculate compression score using the proper formula
             # Check scoring function for details
@@ -2631,8 +2870,10 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
             logger.info(f"♎️ 8. Created distorted video clip in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Calculate VMAF — Docker-first with Y4M fallback
-            # Color/chroma validation still needs Y4M frames, generated after VMAF
+            # Docker path: FFmpeg signalstats for color/chroma validation (no Y4M needed)
+            # Fallback path: Y4M-based VMAF + Y4M-based color/chroma validation
             dist_y4m_path = None
+            used_docker_vmaf = False
             try:
                 vmaf_start = time.time()
                 vmaf_score = None
@@ -2647,26 +2888,22 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
                             n_subsample=1,
                         )
                         logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
+                        used_docker_vmaf = True
                     except Exception as docker_err:
                         logger.warning(f"Docker VMAF failed, falling back to Y4M: {docker_err}")
                         vmaf_score = None
 
-                # Y4M conversion is always needed for color validation
-                ref_clip_frames = get_frame_count(ref_clip_path)
-                logger.info(f"Reference clip has {ref_clip_frames} frames.")
-                random_frames = sorted(random.sample(range(ref_clip_frames), min(VMAF_SAMPLE_COUNT, ref_clip_frames)))
-                ref_y4m_path = convert_mp4_to_y4m(ref_clip_path, random_frames)
-                logger.info("The reference video clip has been successfully converted to Y4M format.")
-                step_time = time.time() - uid_start_time
-                logger.info(f"♎️ 9. Converted reference video clip to Y4M in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
-
                 if vmaf_score is None:
                     # Fallback: Y4M-based VMAF calculation
                     logger.info("Using Y4M-based VMAF calculation (fallback)...")
+                    ref_clip_frames = get_frame_count(ref_clip_path)
+                    logger.info(f"Reference clip has {ref_clip_frames} frames.")
+                    random_frames = sorted(random.sample(range(ref_clip_frames), min(VMAF_SAMPLE_COUNT, ref_clip_frames)))
+                    ref_y4m_path = convert_mp4_to_y4m(ref_clip_path, random_frames)
+                    logger.info("The reference video clip has been successfully converted to Y4M format.")
+                    step_time = time.time() - uid_start_time
+                    logger.info(f"♎️ 9. Converted reference video clip to Y4M in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
                     vmaf_score, dist_y4m_path = calculate_vmaf(ref_y4m_path, dist_clip_path, random_frames, neg_model=True, return_y4m_path=True)
-                else:
-                    # Docker succeeded, but still generate dist Y4M for color validation
-                    dist_y4m_path = convert_mp4_to_y4m(dist_clip_path, random_frames)
 
                 vmaf_calc_time = time.time() - vmaf_start
                 logger.info(f"☣️☣️ VMAF calculation took {vmaf_calc_time:.2f} seconds.")
@@ -2689,64 +2926,101 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
                 if dist_y4m_path and os.path.exists(dist_y4m_path):
                     os.unlink(dist_y4m_path)
                 continue
-            
-            # Now reuse the Y4M files for color validation (no redundant conversion!)
-            # Extract frames for color validation from Y4M files
-            logger.info(f"Extracting frames from Y4M for color validation from clip (reusing VMAF Y4M files)")
-            dist_clip_frames = extract_frames_from_y4m(dist_y4m_path)
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 10.5. Extracted {len(dist_clip_frames)} frames from Y4M for color validation in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
-            # Extract reference frames from Y4M for chroma quality comparison
-            ref_clip_frames_data = extract_frames_from_y4m(ref_y4m_path)
+            # === COLOR / CHROMA VALIDATION ===
+            if used_docker_vmaf:
+                # Docker path: use FFmpeg signalstats directly on trimmed clips (no Y4M needed)
+                logger.info("Using FFmpeg signalstats for color/chroma validation (no Y4M conversion)")
 
-            # Validate color channels (grayscale check)
-            color_valid, color_reason = validate_color_channels_on_frames(ref_clip_frames_data, dist_clip_frames)
-            if not color_valid:
-                logger.error(f"UID {uid}: {color_reason}")
-                # vmaf_scores.append(0.0)
-                compression_rates.append(0.9999) 
-                final_scores.append(0.0)
-                reasons.append(f"Color validation failed: {color_reason}")
-                if dist_path and os.path.exists(dist_path):
-                    os.unlink(dist_path)
-                if ref_clip_path and os.path.exists(ref_clip_path):
-                    os.unlink(ref_clip_path)
-                if dist_clip_path and os.path.exists(dist_clip_path):
-                    os.unlink(dist_clip_path)
-                if dist_y4m_path and os.path.exists(dist_y4m_path):
-                    os.unlink(dist_y4m_path)
-                continue
-            
-            logger.info(f"✅ UID {uid}: Color channels validated - {color_reason}")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 10.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+                # Color validation (grayscale detection)
+                color_valid, color_reason = validate_color_channels_ffmpeg(ref_clip_path, dist_clip_path)
+                if not color_valid:
+                    logger.error(f"UID {uid}: {color_reason}")
+                    compression_rates.append(0.9999)
+                    final_scores.append(0.0)
+                    reasons.append(f"Color validation failed: {color_reason}")
+                    if dist_path and os.path.exists(dist_path):
+                        os.unlink(dist_path)
+                    if ref_clip_path and os.path.exists(ref_clip_path):
+                        os.unlink(ref_clip_path)
+                    if dist_clip_path and os.path.exists(dist_clip_path):
+                        os.unlink(dist_clip_path)
+                    continue
 
-            
-            
-            # Validate chroma quality (prevents partial UV reduction)
-            chroma_valid, chroma_reason = validate_chroma_quality_on_frames(
-                ref_clip_frames_data, dist_clip_frames, threshold=0.7
-            )
-            if not chroma_valid:
-                logger.error(f"UID {uid}: {chroma_reason}")
-                # vmaf_scores.append(0.0)
-                compression_rates.append(0.9999) 
-                final_scores.append(0.0)
-                reasons.append(f"Chroma validation failed: {chroma_reason}")
-                if dist_path and os.path.exists(dist_path):
-                    os.unlink(dist_path)
-                if ref_clip_path and os.path.exists(ref_clip_path):
-                    os.unlink(ref_clip_path)
-                if dist_clip_path and os.path.exists(dist_clip_path):
-                    os.unlink(dist_clip_path)
-                if dist_y4m_path and os.path.exists(dist_y4m_path):
-                    os.unlink(dist_y4m_path)
-                continue
-            
-            logger.info(f"✅ UID {uid}: Chroma quality validated - {chroma_reason}")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 10.7. Validated chroma quality in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+                logger.info(f"✅ UID {uid}: Color channels validated (ffmpeg) - {color_reason}")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 10.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+
+                # Chroma validation (UV reduction detection)
+                chroma_valid, chroma_reason = validate_chroma_quality_ffmpeg(ref_clip_path, dist_clip_path, threshold=0.7)
+                if not chroma_valid:
+                    logger.error(f"UID {uid}: {chroma_reason}")
+                    compression_rates.append(0.9999)
+                    final_scores.append(0.0)
+                    reasons.append(f"Chroma validation failed: {chroma_reason}")
+                    if dist_path and os.path.exists(dist_path):
+                        os.unlink(dist_path)
+                    if ref_clip_path and os.path.exists(ref_clip_path):
+                        os.unlink(ref_clip_path)
+                    if dist_clip_path and os.path.exists(dist_clip_path):
+                        os.unlink(dist_clip_path)
+                    continue
+
+                logger.info(f"✅ UID {uid}: Chroma quality validated (ffmpeg) - {chroma_reason}")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 10.7. Validated chroma quality in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+            else:
+                # Fallback path: use Y4M-based validation (existing approach)
+                logger.info("Extracting frames from Y4M for color validation from clip (reusing VMAF Y4M files)")
+                dist_clip_frames = extract_frames_from_y4m(dist_y4m_path)
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 10.5. Extracted {len(dist_clip_frames)} frames from Y4M for color validation in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+
+                ref_clip_frames_data = extract_frames_from_y4m(ref_y4m_path)
+
+                # Validate color channels (grayscale check)
+                color_valid, color_reason = validate_color_channels_on_frames(ref_clip_frames_data, dist_clip_frames)
+                if not color_valid:
+                    logger.error(f"UID {uid}: {color_reason}")
+                    compression_rates.append(0.9999)
+                    final_scores.append(0.0)
+                    reasons.append(f"Color validation failed: {color_reason}")
+                    if dist_path and os.path.exists(dist_path):
+                        os.unlink(dist_path)
+                    if ref_clip_path and os.path.exists(ref_clip_path):
+                        os.unlink(ref_clip_path)
+                    if dist_clip_path and os.path.exists(dist_clip_path):
+                        os.unlink(dist_clip_path)
+                    if dist_y4m_path and os.path.exists(dist_y4m_path):
+                        os.unlink(dist_y4m_path)
+                    continue
+
+                logger.info(f"✅ UID {uid}: Color channels validated - {color_reason}")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 10.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+
+                # Validate chroma quality (prevents partial UV reduction)
+                chroma_valid, chroma_reason = validate_chroma_quality_on_frames(
+                    ref_clip_frames_data, dist_clip_frames, threshold=0.7
+                )
+                if not chroma_valid:
+                    logger.error(f"UID {uid}: {chroma_reason}")
+                    compression_rates.append(0.9999)
+                    final_scores.append(0.0)
+                    reasons.append(f"Chroma validation failed: {chroma_reason}")
+                    if dist_path and os.path.exists(dist_path):
+                        os.unlink(dist_path)
+                    if ref_clip_path and os.path.exists(ref_clip_path):
+                        os.unlink(ref_clip_path)
+                    if dist_clip_path and os.path.exists(dist_clip_path):
+                        os.unlink(dist_clip_path)
+                    if dist_y4m_path and os.path.exists(dist_y4m_path):
+                        os.unlink(dist_y4m_path)
+                    continue
+
+                logger.info(f"✅ UID {uid}: Chroma quality validated - {chroma_reason}")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 10.7. Validated chroma quality in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
             # Calculate compression score using the proper formula
             # Check scoring function for details

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -21,7 +21,7 @@ from fastapi import FastAPI, HTTPException
 import torchvision.transforms as transforms
 from pieapp_metric import calculate_pieapp_score
 from vidaio_subnet_core.utilities.storage_client import storage_client
-from vmaf_metric import calculate_vmaf, convert_mp4_to_y4m, trim_video, vmaf_metric_ffmpeg, is_vmaf_ffmpeg_available
+from vmaf_metric import calculate_vmaf, convert_mp4_to_y4m, trim_video, trim_video_select, vmaf_metric_ffmpeg, is_vmaf_ffmpeg_available
 from services.video_scheduler.video_utils import get_trim_video_path, delete_videos_with_fileid
 from scoring_function import calculate_compression_score
 
@@ -1829,16 +1829,15 @@ async def score_upscaling_synthetics(request: UpscalingScoringRequest) -> Upscal
             try:
                 vmaf_start = time.time()
 
-                # Trim 1-second clips for VMAF calculation
+                # Trim 1-second clips for VMAF calculation (frame-accurate)
                 ref_fps = get_video_fps(ref_path) or 30.0
-                ref_duration = ref_total_frames / ref_fps
-                vmaf_clip_duration = 1  # seconds
-                max_start = max(0, ref_duration - vmaf_clip_duration)
-                vmaf_start_time = random.uniform(0, max_start)
+                vmaf_num_frames = int(ref_fps)  # 1 second worth of frames
+                max_start_frame = max(0, ref_total_frames - vmaf_num_frames)
+                vmaf_start_frame = random.randint(0, max_start_frame)
 
-                ref_clip_vmaf_path = trim_video(ref_path, vmaf_start_time, vmaf_clip_duration)
-                dist_clip_vmaf_path = trim_video(dist_path, vmaf_start_time, vmaf_clip_duration)
-                logger.info(f"Trimmed 1s clips at {vmaf_start_time:.2f}s for VMAF calculation")
+                ref_clip_vmaf_path = trim_video_select(ref_path, vmaf_start_frame, vmaf_num_frames)
+                dist_clip_vmaf_path = trim_video_select(dist_path, vmaf_start_frame, vmaf_num_frames)
+                logger.info(f"Trimmed {vmaf_num_frames} frames starting at frame {vmaf_start_frame} for VMAF calculation")
 
                 if VMAF_FFMPEG_AVAILABLE and ref_clip_vmaf_path and dist_clip_vmaf_path:
                     try:
@@ -2176,16 +2175,15 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                 vmaf_start = time.time()
                 vmaf_score = None
 
-                # Trim 1-second clips for VMAF calculation
+                # Trim 1-second clips for VMAF calculation (frame-accurate)
                 ref_fps_val = get_video_fps(ref_path) or 30.0
-                ref_duration = ref_total_frames / ref_fps_val
-                vmaf_clip_duration = 1  # seconds
-                max_start = max(0, ref_duration - vmaf_clip_duration)
-                vmaf_start_time = random.uniform(0, max_start)
+                vmaf_num_frames = int(ref_fps_val)  # 1 second worth of frames
+                max_start_frame = max(0, ref_total_frames - vmaf_num_frames)
+                vmaf_start_frame = random.randint(0, max_start_frame)
 
-                ref_clip_vmaf_path = trim_video(ref_path, vmaf_start_time, vmaf_clip_duration)
-                dist_clip_vmaf_path = trim_video(dist_path, vmaf_start_time, vmaf_clip_duration)
-                logger.info(f"Trimmed 1s clips at {vmaf_start_time:.2f}s for VMAF calculation")
+                ref_clip_vmaf_path = trim_video_select(ref_path, vmaf_start_frame, vmaf_num_frames)
+                dist_clip_vmaf_path = trim_video_select(dist_path, vmaf_start_frame, vmaf_num_frames)
+                logger.info(f"Trimmed {vmaf_num_frames} frames starting at frame {vmaf_start_frame} for VMAF calculation")
 
                 if VMAF_FFMPEG_AVAILABLE and ref_clip_vmaf_path and dist_clip_vmaf_path:
                     try:
@@ -2244,8 +2242,11 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                 logger.info("Using FFmpeg signalstats for color/chroma validation (no Y4M conversion)")
 
                 # Compute signalstats once on original videos (not trimmed clips — avoids keyframe issues)
-                ref_signal_stats = _get_signalstats(ref_path, start_time=vmaf_start_time, duration=vmaf_clip_duration)
-                dist_signal_stats = _get_signalstats(dist_path, start_time=vmaf_start_time, duration=vmaf_clip_duration)
+                # Convert frame-based position back to time for signalstats
+                signalstats_start_time = vmaf_start_frame / ref_fps_val
+                signalstats_duration = vmaf_num_frames / ref_fps_val
+                ref_signal_stats = _get_signalstats(ref_path, start_time=signalstats_start_time, duration=signalstats_duration)
+                dist_signal_stats = _get_signalstats(dist_path, start_time=signalstats_start_time, duration=signalstats_duration)
 
                 # Color validation (grayscale detection)
                 color_valid, color_reason = validate_color_channels_ffmpeg(ref_signal_stats, dist_signal_stats)
@@ -2601,22 +2602,18 @@ async def score_organics_upscaling(request: OrganicsUpscalingScoringRequest) -> 
 
         # === MAIN SCORING LOGIC ===
         try:
-            # Calculate 0.25 second clip duration
-            clip_duration = 0.25  # seconds
-            
-            # Calculate maximum start time to ensure we don't exceed video length
-            ref_duration = ref_total_frames / ref_fps
-            max_start_time = max(0, ref_duration - clip_duration)
-            start_time = random.uniform(0, max_start_time)
-            
-            logger.info(f"Creating 0.25-second clips starting from {start_time:.2f} seconds")
-            
-            # Create 0.25-second reference clip (re-encode needed for upscale_video compatibility)
-            ref_clip_path = trim_video(ref_path, start_time, clip_duration, reencode=True)
+            # Calculate 0.25 second clip using frame-accurate extraction
+            clip_num_frames = max(1, int(ref_fps * 0.25))  # 0.25 seconds worth of frames
+            max_start_frame = max(0, ref_total_frames - clip_num_frames)
+            start_frame = random.randint(0, max_start_frame)
+
+            logger.info(f"Creating {clip_num_frames}-frame clips starting at frame {start_frame}")
+
+            # Frame-accurate extraction for both ref and dist
+            ref_clip_path = trim_video_select(ref_path, start_frame, clip_num_frames)
             logger.info(f"Created reference clip: {ref_clip_path}")
-            
-            # Create 0.25-second distorted clip
-            dist_clip_path = trim_video(dist_path, start_time, clip_duration)
+
+            dist_clip_path = trim_video_select(dist_path, start_frame, clip_num_frames)
             logger.info(f"Created distorted clip: {dist_clip_path}")
             
             # Upscale the reference clip
@@ -2901,30 +2898,26 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
                 compression_rate = 1.0
                 logger.info("Reference file size is 0 or distorted file size >= reference, setting compression rate to 1.0")
 
-            # Calculate 0.5 second clip duration for VMAF calculation
-            clip_duration = 0.5  # seconds
-            
-            # Get video FPS to calculate frame-based timing using ffprobe (no AV1 warnings)
+            # Calculate 0.5 second clip using frame-accurate extraction
             ref_fps = get_video_fps(ref_path)
             logger.info(f"Reference video FPS: {ref_fps}")
-            
-            # Calculate maximum start time to ensure we don't exceed video length
-            ref_duration = ref_total_frames / ref_fps
-            max_start_time = max(0, ref_duration - clip_duration)
-            start_time = random.uniform(0, max_start_time)
-            
-            logger.info(f"Creating 0.5-second clips starting from {start_time:.2f} seconds")
-            step_time = time.time() - uid_start_time
-            logger.info(f"♎️ 6. Selected random start time for video chunks in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
-            # Create 0.5-second reference clip
-            ref_clip_path = trim_video(ref_path, start_time, clip_duration)
+            clip_num_frames = max(1, int(ref_fps * 0.5))  # 0.5 seconds worth of frames
+            max_start_frame = max(0, ref_total_frames - clip_num_frames)
+            start_frame = random.randint(0, max_start_frame)
+
+            logger.info(f"Creating {clip_num_frames}-frame clips starting at frame {start_frame}")
+            step_time = time.time() - uid_start_time
+            logger.info(f"♎️ 6. Selected random start frame for video chunks in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+
+            # Create reference clip (frame-accurate)
+            ref_clip_path = trim_video_select(ref_path, start_frame, clip_num_frames)
             logger.info(f"Created reference clip: {ref_clip_path}")
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 7. Created reference video clip in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
-            # Create 0.5-second distorted clip
-            dist_clip_path = trim_video(dist_path, start_time, clip_duration)
+            # Create distorted clip (frame-accurate)
+            dist_clip_path = trim_video_select(dist_path, start_frame, clip_num_frames)
             logger.info(f"Created distorted clip: {dist_clip_path}")
             step_time = time.time() - uid_start_time
             logger.info(f"♎️ 8. Created distorted video clip in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
@@ -2993,8 +2986,11 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
                 logger.info("Using FFmpeg signalstats for color/chroma validation (no Y4M conversion)")
 
                 # Compute signalstats once on original videos (not trimmed clips — avoids keyframe issues)
-                ref_signal_stats = _get_signalstats(ref_path, start_time=start_time, duration=clip_duration)
-                dist_signal_stats = _get_signalstats(dist_path, start_time=start_time, duration=clip_duration)
+                # Convert frame-based position back to time for signalstats
+                signalstats_start_time = start_frame / ref_fps
+                signalstats_duration = clip_num_frames / ref_fps
+                ref_signal_stats = _get_signalstats(ref_path, start_time=signalstats_start_time, duration=signalstats_duration)
+                dist_signal_stats = _get_signalstats(dist_path, start_time=signalstats_start_time, duration=signalstats_duration)
 
                 # Color validation (grayscale detection)
                 color_valid, color_reason = validate_color_channels_ffmpeg(ref_signal_stats, dist_signal_stats)

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -2192,6 +2192,7 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                         vmaf_score = vmaf_metric_ffmpeg(
                             dist_path=dist_path,
                             ref_path=ref_path,
+                            neg_model=True,
                             # skip_frames=np.random.randint(0, ref_fps_val),
                             # n_subsample=np.random.randint(20, 30),
                         )
@@ -2941,6 +2942,7 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
                             ref_path=ref_clip_path,
                             skip_frames=0,
                             n_subsample=1,
+                            neg_model=True,
                         )
                         logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
                         used_docker_vmaf = True

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -629,8 +629,8 @@ def _get_signalstats(video_path, n_subsample=1):
 
 
 def validate_color_channels_ffmpeg(
-    ref_path,
-    dist_path,
+    ref_stats,
+    dist_stats,
     max_gray_ratio=0.50,
     brightness_threshold=20.0,
     ref_sat_threshold=6.0,
@@ -638,7 +638,7 @@ def validate_color_channels_ffmpeg(
     min_checked_frames=3,
 ):
     """
-    FFmpeg-based color validation using signalstats SATAVG.
+    FFmpeg-based color validation using pre-computed signalstats.
     Detects grayscale conversion by comparing per-frame saturation.
 
     Uses the same logic as validate_color_channels_on_frames:
@@ -648,8 +648,8 @@ def validate_color_channels_ffmpeg(
       - Fail if too many distorted frames lost color
 
     Args:
-        ref_path: Path to reference video (MP4)
-        dist_path: Path to distorted video (MP4)
+        ref_stats: Pre-computed signalstats for reference video (from _get_signalstats)
+        dist_stats: Pre-computed signalstats for distorted video (from _get_signalstats)
         max_gray_ratio: Max fraction of frames allowed with reduced color
         brightness_threshold: Min YAVG to consider a ref frame
         ref_sat_threshold: Min ref SATAVG to consider frame as colorful
@@ -660,8 +660,6 @@ def validate_color_channels_ffmpeg(
         tuple: (is_valid, reason)
     """
     try:
-        ref_stats = _get_signalstats(ref_path)
-        dist_stats = _get_signalstats(dist_path)
 
         if not ref_stats or not dist_stats:
             return False, "No frames available for color validation (signalstats)"
@@ -722,9 +720,9 @@ def validate_color_channels_ffmpeg(
         return False, f"Error during color validation: {str(e)}"
 
 
-def validate_chroma_quality_ffmpeg(ref_path, dist_path, threshold=0.7):
+def validate_chroma_quality_ffmpeg(ref_stats, dist_stats, threshold=0.7):
     """
-    FFmpeg-based chroma validation using signalstats SATAVG.
+    FFmpeg-based chroma validation using pre-computed signalstats.
     Detects partial UV channel reduction by comparing saturation energy.
 
     Uses SATAVG² as a proxy for chroma energy (var(U) + var(V)),
@@ -735,17 +733,14 @@ def validate_chroma_quality_ffmpeg(ref_path, dist_path, threshold=0.7):
       - If all frames are low-energy, validation passes (content is valid B&W)
 
     Args:
-        ref_path: Path to reference video (MP4)
-        dist_path: Path to distorted video (MP4)
+        ref_stats: Pre-computed signalstats for reference video (from _get_signalstats)
+        dist_stats: Pre-computed signalstats for distorted video (from _get_signalstats)
         threshold: Minimum acceptable chroma energy ratio (0.0-1.0)
 
     Returns:
         tuple: (is_valid, reason)
     """
     try:
-        ref_stats = _get_signalstats(ref_path)
-        dist_stats = _get_signalstats(dist_path)
-
         if not ref_stats or not dist_stats:
             return False, "No frames available for chroma validation (signalstats)"
 
@@ -2227,8 +2222,12 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                 logger.info("Using FFmpeg signalstats for color/chroma validation (no Y4M conversion)")
 
                 try:
+                    # Compute signalstats once for both validations
+                    ref_signal_stats = _get_signalstats(ref_clip_vmaf_path)
+                    dist_signal_stats = _get_signalstats(dist_clip_vmaf_path)
+
                     # Color validation (grayscale detection)
-                    color_valid, color_reason = validate_color_channels_ffmpeg(ref_clip_vmaf_path, dist_clip_vmaf_path)
+                    color_valid, color_reason = validate_color_channels_ffmpeg(ref_signal_stats, dist_signal_stats)
                     if not color_valid:
                         logger.error(f"UID {uid}: {color_reason}")
                         compression_rates.append(0.9999)
@@ -2241,7 +2240,7 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                     logger.info(f"♎️ 8.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
                     # Chroma validation (UV reduction detection)
-                    chroma_valid, chroma_reason = validate_chroma_quality_ffmpeg(ref_clip_vmaf_path, dist_clip_vmaf_path, threshold=0.7)
+                    chroma_valid, chroma_reason = validate_chroma_quality_ffmpeg(ref_signal_stats, dist_signal_stats, threshold=0.7)
                     if not chroma_valid:
                         logger.error(f"UID {uid}: {chroma_reason}")
                         compression_rates.append(0.9999)
@@ -2978,8 +2977,12 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
                 # Docker path: use FFmpeg signalstats directly on trimmed clips (no Y4M needed)
                 logger.info("Using FFmpeg signalstats for color/chroma validation (no Y4M conversion)")
 
+                # Compute signalstats once for both validations
+                ref_signal_stats = _get_signalstats(ref_clip_path)
+                dist_signal_stats = _get_signalstats(dist_clip_path)
+
                 # Color validation (grayscale detection)
-                color_valid, color_reason = validate_color_channels_ffmpeg(ref_clip_path, dist_clip_path)
+                color_valid, color_reason = validate_color_channels_ffmpeg(ref_signal_stats, dist_signal_stats)
                 if not color_valid:
                     logger.error(f"UID {uid}: {color_reason}")
                     compression_rates.append(0.9999)
@@ -2998,7 +3001,7 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
                 logger.info(f"♎️ 10.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
                 # Chroma validation (UV reduction detection)
-                chroma_valid, chroma_reason = validate_chroma_quality_ffmpeg(ref_clip_path, dist_clip_path, threshold=0.7)
+                chroma_valid, chroma_reason = validate_chroma_quality_ffmpeg(ref_signal_stats, dist_signal_stats, threshold=0.7)
                 if not chroma_valid:
                     logger.error(f"UID {uid}: {chroma_reason}")
                     compression_rates.append(0.9999)

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -550,34 +550,55 @@ def _get_signalstats(video_path):
     Extracts YAVG (luma average) and SATAVG (saturation average) per frame
     directly from the MP4 — no Y4M conversion needed.
 
+    Uses metadata=mode=print to ensure stats are printed to stderr in the
+    format: lavfi.signalstats.KEY=VALUE
+
     Returns:
         list of dicts, each with at least 'YAVG' and 'SATAVG' keys.
     """
     cmd = [
         "ffmpeg",
         "-i", video_path,
-        "-vf", "signalstats",
+        "-vf", "signalstats,metadata=mode=print",
         "-f", "null", "-",
-        "-hide_banner",
+        "-hide_banner", "-loglevel", "info",
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
 
     frames = []
+    current_frame = {}
+
     for line in result.stderr.split('\n'):
-        if 'Parsed_signalstats' not in line:
-            continue
-        stats = {}
-        for token in line.split():
-            if ':' not in token:
-                continue
-            key, _, val = token.partition(':')
-            try:
-                stats[key] = float(val)
-            except ValueError:
-                pass
-        if 'SATAVG' in stats and 'YAVG' in stats:
-            frames.append(stats)
+        line = line.strip()
+
+        # New frame boundary: "frame:N ..." line
+        if line.startswith('frame:'):
+            # Save the previous frame if it has the keys we need
+            if current_frame and 'SATAVG' in current_frame and 'YAVG' in current_frame:
+                frames.append(current_frame)
+            current_frame = {}
+        elif 'lavfi.signalstats.' in line:
+            # Parse: "lavfi.signalstats.SATAVG=29.800000"
+            parts = line.split('lavfi.signalstats.', 1)
+            if len(parts) == 2:
+                key_val = parts[1]
+                if '=' in key_val:
+                    key, val = key_val.split('=', 1)
+                    try:
+                        current_frame[key] = float(val)
+                    except ValueError:
+                        pass
+
+    # Don't forget the last frame
+    if current_frame and 'SATAVG' in current_frame and 'YAVG' in current_frame:
+        frames.append(current_frame)
+
+    if not frames:
+        logger.warning(
+            f"signalstats returned 0 frames for {video_path}. "
+            f"FFmpeg returncode={result.returncode}, stderr length={len(result.stderr)}"
+        )
 
     return frames
 

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -2192,8 +2192,8 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                         vmaf_score = vmaf_metric_ffmpeg(
                             dist_path=dist_path,
                             ref_path=ref_path,
-                            skip_frames=np.random.randint(0, ref_fps_val),
-                            n_subsample=np.random.randint(20, 30),
+                            # skip_frames=np.random.randint(0, ref_fps_val),
+                            # n_subsample=np.random.randint(20, 30),
                         )
                         logger.info(f"Docker VMAF calculation succeeded: {vmaf_score}")
                         used_docker_vmaf = True

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -544,27 +544,52 @@ def validate_chroma_quality_on_frames(ref_frames, dist_frames, threshold=0.7):
         return False, f"Error validating chroma: {str(e)}"
 
 
-def _get_signalstats(video_path):
+def _get_signalstats(video_path, n_subsample=1):
     """
     Run ffmpeg signalstats filter on a video and return per-frame statistics.
     Extracts YAVG (luma average) and SATAVG (saturation average) per frame
     directly from the MP4 — no Y4M conversion needed.
 
-    Uses metadata=mode=print to ensure stats are printed to stderr in the
-    format: lavfi.signalstats.KEY=VALUE
+    Uses CUDA hardware-accelerated decoding when available, falling back to
+    CPU if GPU decode fails. Uses metadata=mode=print to ensure stats are
+    printed to stderr.
+
+    Args:
+        video_path: Path to input video
+        n_subsample: Analyze every Nth frame (1 = all frames, 5 = every 5th frame)
 
     Returns:
         list of dicts, each with at least 'YAVG' and 'SATAVG' keys.
     """
-    cmd = [
+    # Build filter chain
+    if n_subsample > 1:
+        vf = f"select='not(mod(n\\,{n_subsample}))',signalstats,metadata=mode=print"
+    else:
+        vf = "signalstats,metadata=mode=print"
+
+    # Try GPU-accelerated decoding first (NVDEC)
+    cmd_gpu = [
         "ffmpeg",
+        "-hwaccel", "cuda",
         "-i", video_path,
-        "-vf", "signalstats,metadata=mode=print",
+        "-vf", vf,
         "-f", "null", "-",
         "-hide_banner", "-loglevel", "info",
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    result = subprocess.run(cmd_gpu, capture_output=True, text=True, timeout=120)
+
+    # If GPU decode failed, fall back to CPU
+    if result.returncode != 0:
+        logger.info(f"GPU decode failed for signalstats, falling back to CPU decode")
+        cmd_cpu = [
+            "ffmpeg",
+            "-i", video_path,
+            "-vf", vf,
+            "-f", "null", "-",
+            "-hide_banner", "-loglevel", "info",
+        ]
+        result = subprocess.run(cmd_cpu, capture_output=True, text=True, timeout=120)
 
     frames = []
     current_frame = {}

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -544,7 +544,7 @@ def validate_chroma_quality_on_frames(ref_frames, dist_frames, threshold=0.7):
         return False, f"Error validating chroma: {str(e)}"
 
 
-def _get_signalstats(video_path, n_subsample=1):
+def _get_signalstats(video_path, n_subsample=1, start_time=None, duration=None, max_frames=30):
     """
     Run ffmpeg signalstats filter on a video and return per-frame statistics.
     Extracts YAVG (luma average) and SATAVG (saturation average) per frame
@@ -554,9 +554,16 @@ def _get_signalstats(video_path, n_subsample=1):
     CPU if GPU decode fails. Uses metadata=mode=print to ensure stats are
     printed to stderr.
 
+    FFmpeg processing is bounded by max_frames — FFmpeg stops decoding after
+    max_frames frames, so even hour-long videos are fast.
+
     Args:
         video_path: Path to input video
         n_subsample: Analyze every Nth frame (1 = all frames, 5 = every 5th frame)
+        start_time: Optional start time in seconds (analyze from this point)
+        duration: Optional duration in seconds (analyze this many seconds)
+        max_frames: Maximum number of frames FFmpeg will decode (default 30).
+                    FFmpeg stops after this many frames via -frames:v.
 
     Returns:
         list of dicts, each with at least 'YAVG' and 'SATAVG' keys.
@@ -567,12 +574,24 @@ def _get_signalstats(video_path, n_subsample=1):
     else:
         vf = "signalstats,metadata=mode=print"
 
+    # Build seek/duration args (placed before -i for fast input seeking)
+    seek_args = []
+    if start_time is not None:
+        seek_args += ["-ss", str(start_time)]
+    if duration is not None:
+        seek_args += ["-t", str(duration)]
+
+    # -frames:v tells FFmpeg to stop after processing this many frames
+    frame_limit_args = ["-frames:v", str(max_frames)] if max_frames else []
+
     # Try GPU-accelerated decoding first (NVDEC)
     cmd_gpu = [
         "ffmpeg",
         "-hwaccel", "cuda",
+    ] + seek_args + [
         "-i", video_path,
         "-vf", vf,
+    ] + frame_limit_args + [
         "-f", "null", "-",
         "-hide_banner", "-loglevel", "info",
     ]
@@ -584,8 +603,10 @@ def _get_signalstats(video_path, n_subsample=1):
         logger.info(f"GPU decode failed for signalstats, falling back to CPU decode")
         cmd_cpu = [
             "ffmpeg",
+        ] + seek_args + [
             "-i", video_path,
             "-vf", vf,
+        ] + frame_limit_args + [
             "-f", "null", "-",
             "-hide_banner", "-loglevel", "info",
         ]
@@ -624,6 +645,8 @@ def _get_signalstats(video_path, n_subsample=1):
             f"signalstats returned 0 frames for {video_path}. "
             f"FFmpeg returncode={result.returncode}, stderr length={len(result.stderr)}"
         )
+    else:
+        logger.info(f"signalstats collected {len(frames)} frames for {os.path.basename(video_path)}")
 
     return frames
 
@@ -2208,55 +2231,46 @@ async def score_compression_synthetics(request: CompressionScoringRequest) -> Co
                     os.unlink(dist_y4m_path)
                 continue
             finally:
-                # Clean up trimmed VMAF clips only if we're NOT using them for FFmpeg validation
-                # If Docker was used, we still need the clips for signalstats validation below
-                if not used_docker_vmaf:
-                    if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
-                        os.unlink(ref_clip_vmaf_path)
-                    if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
-                        os.unlink(dist_clip_vmaf_path)
+                # Clean up trimmed VMAF clips — signalstats runs on originals, not clips
+                if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
+                    os.unlink(ref_clip_vmaf_path)
+                if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
+                    os.unlink(dist_clip_vmaf_path)
 
             # === COLOR / CHROMA VALIDATION ===
             if used_docker_vmaf:
-                # Docker path: use FFmpeg signalstats directly on trimmed clips (no Y4M needed)
+                # Docker path: use FFmpeg signalstats on original videos with time bounds (no Y4M needed)
                 logger.info("Using FFmpeg signalstats for color/chroma validation (no Y4M conversion)")
 
-                try:
-                    # Compute signalstats once for both validations
-                    ref_signal_stats = _get_signalstats(ref_clip_vmaf_path)
-                    dist_signal_stats = _get_signalstats(dist_clip_vmaf_path)
+                # Compute signalstats once on original videos (not trimmed clips — avoids keyframe issues)
+                ref_signal_stats = _get_signalstats(ref_path, start_time=vmaf_start_time, duration=vmaf_clip_duration)
+                dist_signal_stats = _get_signalstats(dist_path, start_time=vmaf_start_time, duration=vmaf_clip_duration)
 
-                    # Color validation (grayscale detection)
-                    color_valid, color_reason = validate_color_channels_ffmpeg(ref_signal_stats, dist_signal_stats)
-                    if not color_valid:
-                        logger.error(f"UID {uid}: {color_reason}")
-                        compression_rates.append(0.9999)
-                        final_scores.append(0.0)
-                        reasons.append(f"Color validation failed: {color_reason}")
-                        continue
+                # Color validation (grayscale detection)
+                color_valid, color_reason = validate_color_channels_ffmpeg(ref_signal_stats, dist_signal_stats)
+                if not color_valid:
+                    logger.error(f"UID {uid}: {color_reason}")
+                    compression_rates.append(0.9999)
+                    final_scores.append(0.0)
+                    reasons.append(f"Color validation failed: {color_reason}")
+                    continue
 
-                    logger.info(f"✅ UID {uid}: Color channels validated (ffmpeg) - {color_reason}")
-                    step_time = time.time() - uid_start_time
-                    logger.info(f"♎️ 8.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
+                logger.info(f"✅ UID {uid}: Color channels validated (ffmpeg) - {color_reason}")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 8.6. Validated color channels in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
 
-                    # Chroma validation (UV reduction detection)
-                    chroma_valid, chroma_reason = validate_chroma_quality_ffmpeg(ref_signal_stats, dist_signal_stats, threshold=0.7)
-                    if not chroma_valid:
-                        logger.error(f"UID {uid}: {chroma_reason}")
-                        compression_rates.append(0.9999)
-                        final_scores.append(0.0)
-                        reasons.append(f"Chroma validation failed: {chroma_reason}")
-                        continue
+                # Chroma validation (UV reduction detection)
+                chroma_valid, chroma_reason = validate_chroma_quality_ffmpeg(ref_signal_stats, dist_signal_stats, threshold=0.7)
+                if not chroma_valid:
+                    logger.error(f"UID {uid}: {chroma_reason}")
+                    compression_rates.append(0.9999)
+                    final_scores.append(0.0)
+                    reasons.append(f"Chroma validation failed: {chroma_reason}")
+                    continue
 
-                    logger.info(f"✅ UID {uid}: Chroma quality validated (ffmpeg) - {chroma_reason}")
-                    step_time = time.time() - uid_start_time
-                    logger.info(f"♎️ 8.7. Validated chroma quality in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
-                finally:
-                    # Clean up trimmed clips after FFmpeg validation
-                    if ref_clip_vmaf_path and os.path.exists(ref_clip_vmaf_path):
-                        os.unlink(ref_clip_vmaf_path)
-                    if dist_clip_vmaf_path and os.path.exists(dist_clip_vmaf_path):
-                        os.unlink(dist_clip_vmaf_path)
+                logger.info(f"✅ UID {uid}: Chroma quality validated (ffmpeg) - {chroma_reason}")
+                step_time = time.time() - uid_start_time
+                logger.info(f"♎️ 8.7. Validated chroma quality in {step_time:.2f} seconds. Total time: {step_time:.2f} seconds.")
             else:
                 # Fallback path: use Y4M-based validation (existing approach)
                 logger.info("Extracting frames from Y4M for color validation (reusing VMAF Y4M files)")
@@ -2974,12 +2988,12 @@ async def score_organics_compression(request: OrganicsCompressionScoringRequest)
 
             # === COLOR / CHROMA VALIDATION ===
             if used_docker_vmaf:
-                # Docker path: use FFmpeg signalstats directly on trimmed clips (no Y4M needed)
+                # Docker path: use FFmpeg signalstats on original videos with time bounds (no Y4M needed)
                 logger.info("Using FFmpeg signalstats for color/chroma validation (no Y4M conversion)")
 
-                # Compute signalstats once for both validations
-                ref_signal_stats = _get_signalstats(ref_clip_path)
-                dist_signal_stats = _get_signalstats(dist_clip_path)
+                # Compute signalstats once on original videos (not trimmed clips — avoids keyframe issues)
+                ref_signal_stats = _get_signalstats(ref_path, start_time=start_time, duration=clip_duration)
+                dist_signal_stats = _get_signalstats(dist_path, start_time=start_time, duration=clip_duration)
 
                 # Color validation (grayscale detection)
                 color_valid, color_reason = validate_color_channels_ffmpeg(ref_signal_stats, dist_signal_stats)

--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -2312,8 +2312,8 @@ async def score_organics_upscaling(request: OrganicsUpscalingScoringRequest) -> 
             
             logger.info(f"Creating 0.25-second clips starting from {start_time:.2f} seconds")
             
-            # Create 0.25-second reference clip
-            ref_clip_path = trim_video(ref_path, start_time, clip_duration)
+            # Create 0.25-second reference clip (re-encode needed for upscale_video compatibility)
+            ref_clip_path = trim_video(ref_path, start_time, clip_duration, reencode=True)
             logger.info(f"Created reference clip: {ref_clip_path}")
             
             # Create 0.25-second distorted clip

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -100,6 +100,52 @@ def trim_video(input_path, start_time, trim_duration=1, target_crf=18, reencode=
         print(f"Error: {e.stderr.decode()}")
         return None
 
+
+def trim_video_select(input_path, start_frame, num_frames, target_crf=18):
+    """
+    Frame-accurate video trimming using the select filter.
+
+    Unlike trim_video (which uses stream copy or time-based seeking and can
+    land on the wrong keyframe), this function extracts exact frame indices.
+    Both the reference and distorted videos will contain the exact same
+    frame range, eliminating alignment issues in VMAF comparisons.
+
+    Args:
+        input_path (str): Path to the source video.
+        start_frame (int): First frame index to include (0-based).
+        num_frames (int): Number of consecutive frames to extract.
+        target_crf (int): CRF quality for the re-encoded output (default: 18).
+
+    Returns:
+        str: Path to the trimmed MP4 file, or None on error.
+    """
+    filename, ext = os.path.splitext(input_path)
+    output_path = f"{filename}_trimmed_f{start_frame}.mp4"
+
+    end_frame = start_frame + num_frames - 1
+    select_expr = f"between(n\\,{start_frame}\\,{end_frame})"
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i", input_path,
+        "-vf", f"select='{select_expr}',setpts=N/FRAME_RATE/TB",
+        "-an",                 # Drop audio (not needed for VMAF)
+        "-pix_fmt", "yuv420p",
+        "-c:v", "libx264",
+        "-preset", "fast",
+        "-crf", str(target_crf),
+        output_path,
+    ]
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+        return output_path
+    except subprocess.CalledProcessError as e:
+        print(f"Error in trim_video_select: {e.stderr.decode()}")
+        return None
+
+
 def get_video_fps(video_path):
     """
     Get the frame rate of a video using ffprobe.

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -51,32 +51,47 @@ def is_vmaf_ffmpeg_available(docker_image="vmaf_ffmpeg"):
         return False
 
 
-def trim_video(input_path, start_time, trim_duration=1, target_crf=18):
+def trim_video(input_path, start_time, trim_duration=1, target_crf=18, reencode=False):
     """
-    Trims a video and re-encodes it to H.264 with minimal quality loss.
+    Trims a video segment. By default uses stream copy (no re-encoding) for
+    lossless, fast trimming. Set reencode=True to re-encode to H.264, which
+    is needed when the output must be in a standard codec (e.g. for upscale_video).
     
     Args:
         input_path (str): Path to the source (AV1, HEVC, etc.)
         start_time (float): Start point in seconds
         trim_duration (int): Duration in seconds
-        target_crf (int): Quality level (17-18 for visually transparent)
+        target_crf (int): Quality level (17-18 for visually transparent), only used when reencode=True
+        reencode (bool): If True, re-encode to H.264. If False, use stream copy (default).
     """
     filename, ext = os.path.splitext(input_path)
     output_path = f"{filename}_trimmed_{start_time:.2f}.mp4"
     
-    cmd = [
-        "ffmpeg",
-        "-y",                  # Overwrite if exists
-        "-ss", str(start_time),
-        "-t", str(trim_duration),
-        "-i", input_path,
-        "-c:v", "libx264",     # Ensure H.264 output
-        "-preset", "fast",     # Better compression efficiency
-        "-crf", str(target_crf),# High quality setting
-        "-c:a", "aac",         # Standard audio codec for MP4
-        "-b:a", "192k",        # Good audio bitrate
-        output_path
-    ]
+    if reencode:
+        cmd = [
+            "ffmpeg",
+            "-y",                  # Overwrite if exists
+            "-ss", str(start_time),
+            "-t", str(trim_duration),
+            "-i", input_path,
+            "-c:v", "libx264",     # Ensure H.264 output
+            "-preset", "fast",     # Better compression efficiency
+            "-crf", str(target_crf),# High quality setting
+            "-c:a", "aac",         # Standard audio codec for MP4
+            "-b:a", "192k",        # Good audio bitrate
+            output_path
+        ]
+    else:
+        cmd = [
+            "ffmpeg",
+            "-y",                  # Overwrite if exists
+            "-ss", str(start_time),
+            "-t", str(trim_duration),
+            "-i", input_path,
+            "-c:v", "copy",        # Stream copy — no re-encoding
+            "-c:a", "copy",        # Stream copy audio
+            output_path
+        ]
     
     try:
         subprocess.run(cmd, check=True, capture_output=True)

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -278,6 +278,7 @@ def vmaf_metric_ffmpeg(
     skip_frames=0,
     n_subsample=1,
     docker_image="vmaf_ffmpeg",
+    neg_model=False,
 ):
     """
     Calculate VMAF score using the vmaf_ffmpeg Docker container with GPU-accelerated
@@ -328,10 +329,17 @@ def vmaf_metric_ffmpeg(
         else:
             select_filter = ""
 
+        if neg_model:
+            logger.info("Using VMAF NEG model for scoring (ffmpeg/docker).")
+            model_param = ":model='version=vmaf_v0.6.1neg'"
+        else:
+            logger.info("Using standard VMAF model for scoring (ffmpeg/docker).")
+            model_param = ""
+
         filter_complex = (
             f"[0:v]{select_filter}format=yuv420p,hwupload_cuda[dis];"
             f"[1:v]{select_filter}format=yuv420p,hwupload_cuda[ref];"
-            f"[dis][ref]libvmaf_cuda=n_subsample={n_subsample}"
+            f"[dis][ref]libvmaf_cuda=n_subsample={n_subsample}{model_param}"
             f":log_fmt=json:log_path={output_json}"
         )
 

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -8,6 +8,49 @@ import tempfile
 import shutil
 
 
+_vmaf_ffmpeg_available = None  # cached result
+
+def is_vmaf_ffmpeg_available(docker_image="vmaf_ffmpeg"):
+    """
+    Check whether the vmaf_ffmpeg Docker image is available locally and
+    its FFmpeg build supports the libvmaf_cuda filter.
+    The result is cached so the check only runs once per process.
+    """
+    global _vmaf_ffmpeg_available
+    if _vmaf_ffmpeg_available is not None:
+        return _vmaf_ffmpeg_available
+
+    try:
+        # 1. Check if Docker image exists
+        result = subprocess.run(
+            ["docker", "images", "-q", docker_image],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            logger.info(f"vmaf_ffmpeg Docker image '{docker_image}' not found locally.")
+            _vmaf_ffmpeg_available = False
+            return False
+
+        # 2. Check if FFmpeg in the image supports libvmaf_cuda
+        result = subprocess.run(
+            ["docker", "run", "--rm", docker_image, "-filters"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if "libvmaf_cuda" not in (result.stdout + result.stderr):
+            logger.info(f"vmaf_ffmpeg Docker image does not support libvmaf_cuda filter.")
+            _vmaf_ffmpeg_available = False
+            return False
+
+        logger.info("vmaf_ffmpeg Docker image with libvmaf_cuda support detected ✅")
+        _vmaf_ffmpeg_available = True
+        return True
+
+    except Exception as e:
+        logger.warning(f"Error checking vmaf_ffmpeg availability: {e}")
+        _vmaf_ffmpeg_available = False
+        return False
+
+
 def trim_video(input_path, start_time, trim_duration=1, target_crf=18):
     """
     Trims a video and re-encodes it to H.264 with minimal quality loss.

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -1,5 +1,6 @@
 import subprocess
 import xml.etree.ElementTree as ET
+import json
 import os
 from moviepy.editor import VideoFileClip
 from loguru import logger
@@ -165,6 +166,130 @@ def vmaf_metric(ref_path, dist_path, output_file="vmaf_output.xml", neg_model=Fa
     except Exception as e:
         print(f"Error in calculate_vmaf: {e}")
         raise
+
+
+def vmaf_metric_ffmpeg(
+    dist_path,
+    ref_path,
+    skip_frames=0,
+    n_subsample=1,
+    docker_image="vmaf_ffmpeg",
+):
+    """
+    Calculate VMAF score using the vmaf_ffmpeg Docker container with GPU-accelerated
+    libvmaf_cuda, operating directly on MP4 inputs.
+
+    The libvmaf_cuda filter expects: distorted first, reference second.
+    This matches FFmpeg's convention where the first -i is the distorted video
+    and the second -i is the reference video.
+
+    Args:
+        dist_path (str): Absolute path to the distorted MP4 video.
+        ref_path (str): Absolute path to the reference MP4 video.
+        skip_frames (int): Number of leading frames to skip (e.g. 51 to
+            drop the first 51 frames from both streams).
+        n_subsample (int): Subsample every N-th frame for faster scoring.
+        docker_image (str): Name of the Docker image (default "vmaf_ffmpeg").
+
+    Returns:
+        float: The VMAF harmonic mean score.
+    """
+    dist_path = os.path.abspath(dist_path)
+    ref_path = os.path.abspath(ref_path)
+
+    # Collect unique directories that need to be mounted
+    dist_dir = os.path.dirname(dist_path)
+    ref_dir = os.path.dirname(ref_path)
+
+    # Use a temporary directory for the JSON output
+    tmp_dir = tempfile.mkdtemp(prefix="vmaf_ffmpeg_")
+    output_json = os.path.join(tmp_dir, "vmaf_output.json")
+
+    try:
+        # Build volume mounts – map each host dir to the same path inside the
+        # container so that absolute paths work unchanged.
+        volumes = set()
+        volumes.add(dist_dir)
+        volumes.add(ref_dir)
+        volumes.add(tmp_dir)
+
+        vol_args = []
+        for vol in volumes:
+            vol_args.extend(["-v", f"{vol}:{vol}"])
+
+        # Build the filter_complex string
+        # skip_frames: select frames with index > skip_frames (i.e. drop first skip_frames+1 frames)
+        if skip_frames > 0:
+            select_filter = f"select=gt(n\\,{skip_frames}),"
+        else:
+            select_filter = ""
+
+        filter_complex = (
+            f"[0:v]{select_filter}format=yuv420p,hwupload_cuda[dis];"
+            f"[1:v]{select_filter}format=yuv420p,hwupload_cuda[ref];"
+            f"[dis][ref]libvmaf_cuda=n_subsample={n_subsample}"
+            f":log_fmt=json:log_path={output_json}"
+        )
+
+        # Assemble the full docker command
+        # Entrypoint of the image is "ffmpeg", so we only pass ffmpeg args
+        cmd = [
+            "docker", "run", "--rm",
+            "--gpus", "all",
+            *vol_args,
+            docker_image,
+            "-i", dist_path,
+            "-i", ref_path,
+            "-filter_complex", filter_complex,
+            "-f", "null", "-",
+        ]
+
+        logger.info(f"Running VMAF via Docker: {' '.join(cmd)}")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            raise Exception(
+                f"Docker VMAF command failed (exit {result.returncode}):\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+
+        # Parse the JSON log produced by libvmaf_cuda
+        if not os.path.exists(output_json):
+            raise FileNotFoundError(
+                f"Expected VMAF JSON output '{output_json}' not found."
+            )
+
+        with open(output_json, "r") as f:
+            vmaf_data = json.load(f)
+
+        # Extract per-frame VMAF scores
+        frames = vmaf_data.get("frames", [])
+        if not frames:
+            raise ValueError("No frames found in VMAF JSON output.")
+
+        scores = []
+        for frame in frames:
+            metrics = frame.get("metrics", {})
+            vmaf_score = metrics.get("vmaf")
+            if vmaf_score is not None and vmaf_score > 0:
+                scores.append(vmaf_score)
+
+        if not scores:
+            raise ValueError("No valid (> 0) VMAF scores found in output.")
+
+        # Compute harmonic mean: n / sum(1/x_i)
+        harmonic_mean = len(scores) / sum(1.0 / s for s in scores)
+        logger.info(f"VMAF harmonic mean (ffmpeg/docker): {harmonic_mean:.4f}")
+        return harmonic_mean
+
+    except Exception as e:
+        logger.error(f"Error in vmaf_metric_ffmpeg: {e}")
+        raise
+
+    finally:
+        # Clean up temporary directory
+        if os.path.exists(tmp_dir):
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
 def calculate_vmaf(ref_y4m_path, dist_mp4_path, random_frames, neg_model=False, return_y4m_path=False):
     """

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -115,28 +115,55 @@ def trim_video_select(input_path, start_frame, num_frames, target_crf=18):
         start_frame (int): First frame index to include (0-based).
         num_frames (int): Number of consecutive frames to extract.
         target_crf (int): CRF quality for the re-encoded output (default: 18).
+        docker_image (str): Docker image name to use if available.
 
     Returns:
         str: Path to the trimmed MP4 file, or None on error.
     """
-    filename, ext = os.path.splitext(input_path)
-    output_path = f"{filename}_trimmed_f{start_frame}.mp4"
+    # Resolve absolute paths for Docker volume mounting
+    abs_input_path = os.path.abspath(input_path)
+    base_dir = os.path.dirname(abs_input_path)
+    base_name = os.path.basename(abs_input_path)
+
+    filename, ext = os.path.splitext(base_name)
+    output_filename = f"{filename}_trimmed_f{start_frame}.mp4"
+    output_path = os.path.join(base_dir, output_filename)
 
     end_frame = start_frame + num_frames - 1
     select_expr = f"between(n\\,{start_frame}\\,{end_frame})"
 
-    cmd = [
-        "ffmpeg",
-        "-y",
-        "-i", input_path,
-        "-vf", f"select='{select_expr}',setpts=N/FRAME_RATE/TB",
-        "-an",                 # Drop audio (not needed for VMAF)
-        "-pix_fmt", "yuv420p",
-        "-c:v", "libx264",
-        "-preset", "fast",
-        "-crf", str(target_crf),
-        output_path,
-    ]
+    if is_vmaf_ffmpeg_available():
+        logger.info(f"Using Docker image vmaf_ffmpeg with hevc_nvenc for trimming.")
+        cmd = [
+            "docker", "run", "--rm", 
+            "--gpus", "all,\"capabilities=compute,video,utility\"",
+            "-v", f"{base_dir}:/files",
+            "vmaf_ffmpeg",
+            "-y",
+            "-i", f"/files/{base_name}",
+            "-vf", f"select='{select_expr}',setpts=N/FRAME_RATE/TB",
+            "-an",
+            "-pix_fmt", "yuv420p",
+            "-c:v", "hevc_nvenc",   
+            "-preset", "p4",        
+            "-rc", "vbr",
+            "-cq", str(target_crf),
+            f"/files/{output_filename}",
+        ]
+    else:
+        logger.info("Falling back to local FFmpeg for trimming.")
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i", abs_input_path,
+            "-vf", f"select='{select_expr}',setpts=N/FRAME_RATE/TB",
+            "-an",
+            "-pix_fmt", "yuv420p",
+            "-c:v", "libx264",
+            "-preset", "fast",
+            "-crf", str(target_crf),
+            output_path,
+        ]
 
     try:
         subprocess.run(cmd, check=True, capture_output=True)
@@ -144,7 +171,6 @@ def trim_video_select(input_path, start_frame, num_frames, target_crf=18):
     except subprocess.CalledProcessError as e:
         print(f"Error in trim_video_select: {e.stderr.decode()}")
         return None
-
 
 def get_video_fps(video_path):
     """

--- a/services/scoring/vmaf_metric.py
+++ b/services/scoring/vmaf_metric.py
@@ -115,55 +115,28 @@ def trim_video_select(input_path, start_frame, num_frames, target_crf=18):
         start_frame (int): First frame index to include (0-based).
         num_frames (int): Number of consecutive frames to extract.
         target_crf (int): CRF quality for the re-encoded output (default: 18).
-        docker_image (str): Docker image name to use if available.
 
     Returns:
         str: Path to the trimmed MP4 file, or None on error.
     """
-    # Resolve absolute paths for Docker volume mounting
-    abs_input_path = os.path.abspath(input_path)
-    base_dir = os.path.dirname(abs_input_path)
-    base_name = os.path.basename(abs_input_path)
-
-    filename, ext = os.path.splitext(base_name)
-    output_filename = f"{filename}_trimmed_f{start_frame}.mp4"
-    output_path = os.path.join(base_dir, output_filename)
+    filename, ext = os.path.splitext(input_path)
+    output_path = f"{filename}_trimmed_f{start_frame}.mp4"
 
     end_frame = start_frame + num_frames - 1
     select_expr = f"between(n\\,{start_frame}\\,{end_frame})"
 
-    if is_vmaf_ffmpeg_available():
-        logger.info(f"Using Docker image vmaf_ffmpeg with hevc_nvenc for trimming.")
-        cmd = [
-            "docker", "run", "--rm", 
-            "--gpus", "all,\"capabilities=compute,video,utility\"",
-            "-v", f"{base_dir}:/files",
-            "vmaf_ffmpeg",
-            "-y",
-            "-i", f"/files/{base_name}",
-            "-vf", f"select='{select_expr}',setpts=N/FRAME_RATE/TB",
-            "-an",
-            "-pix_fmt", "yuv420p",
-            "-c:v", "hevc_nvenc",   
-            "-preset", "p4",        
-            "-rc", "vbr",
-            "-cq", str(target_crf),
-            f"/files/{output_filename}",
-        ]
-    else:
-        logger.info("Falling back to local FFmpeg for trimming.")
-        cmd = [
-            "ffmpeg",
-            "-y",
-            "-i", abs_input_path,
-            "-vf", f"select='{select_expr}',setpts=N/FRAME_RATE/TB",
-            "-an",
-            "-pix_fmt", "yuv420p",
-            "-c:v", "libx264",
-            "-preset", "fast",
-            "-crf", str(target_crf),
-            output_path,
-        ]
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i", input_path,
+        "-vf", f"select='{select_expr}',setpts=N/FRAME_RATE/TB",
+        "-an",                 # Drop audio (not needed for VMAF)
+        "-pix_fmt", "yuv420p",
+        "-c:v", "libx264",
+        "-preset", "fast",
+        "-crf", str(target_crf),
+        output_path,
+    ]
 
     try:
         subprocess.run(cmd, check=True, capture_output=True)
@@ -171,6 +144,7 @@ def trim_video_select(input_path, start_frame, num_frames, target_crf=18):
     except subprocess.CalledProcessError as e:
         print(f"Error in trim_video_select: {e.stderr.decode()}")
         return None
+
 
 def get_video_fps(video_path):
     """

--- a/vidaio_subnet_core/__init__.py
+++ b/vidaio_subnet_core/__init__.py
@@ -12,7 +12,7 @@ __all__ = [
     "CONFIG",
 ]
 
-__version__ = "2.1.34"
+__version__ = "2.1.35"
 
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/vmaf_utils/Dockerfile
+++ b/vmaf_utils/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:22.04
+ARG NV_CODEC_TAG="876af32a202d0de83bd1d36fe74ee0f7fcf86b0d"
+
+# get and install building tools
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    ninja-build \
+    nasm \
+    doxygen \
+    python3 \
+    python3-pip \
+    python3-venv \
+    xxd \
+    clang \
+    wget \
+    unzip \
+    nvidia-cuda-dev \
+    nvidia-cuda-toolkit
+
+# retrieve source code
+COPY . /vmaf
+
+# setup environment
+
+ENV PATH=/vmaf:/vmaf/libvmaf/build/tools:$PATH
+ENV PKG_CONFIG_PATH="/usr/local/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH"
+
+
+RUN wget https://github.com/FFmpeg/nv-codec-headers/archive/${NV_CODEC_TAG}.zip && unzip ${NV_CODEC_TAG}.zip && cd nv-codec-headers-${NV_CODEC_TAG} && make && make install
+
+# make vmaf
+# when disabling NVCC, libvmaf will be built without cubin's which will compile kernels at start of the container
+RUN cd /vmaf && make clean && make ENABLE_NVCC=true && make install && \
+    set -eux; \
+    for d in /usr/local/lib /usr/local/lib/x86_64-linux-gnu /usr/local/lib64; do \
+        if [ -d "$d" ]; then echo "$d"; fi; \
+    done > /etc/ld.so.conf.d/00-vmaf-local.conf && \
+    ldconfig
+
+# install python tools
+RUN pip3 install --no-cache-dir -r /vmaf/python/requirements.txt
+
+WORKDIR /vmaf
+
+ENV PYTHONPATH=python
+
+ENTRYPOINT [ "vmaf" ]

--- a/vmaf_utils/Dockerfile.ffmpeg
+++ b/vmaf_utils/Dockerfile.ffmpeg
@@ -1,0 +1,46 @@
+FROM vmaf
+
+RUN apt-get update && \
+    apt-get install -y pkg-config libx264-dev git python3-pip && \
+    pip3 install meson
+
+# build dav1d from source (requires >= 1.0.0 for ffmpeg)
+RUN git clone --depth 1 --branch 1.4.2 https://code.videolan.org/videolan/dav1d.git && \
+    cd dav1d && \
+    mkdir build && cd build && \
+    meson setup .. --default-library=static --buildtype release && \
+    ninja && \
+    ninja install && \
+    ldconfig
+
+ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH"
+
+ARG FFMPEG_TAG=master
+ARG NVCC_FLAGS="-gencode arch=compute_75,code=sm_75 -gencode arch=compute_75,code=compute_75 -O2"
+
+# get ffmpeg
+RUN git clone https://github.com/FFmpeg/FFmpeg ffmpeg
+
+RUN cd ffmpeg && git reset --hard 33b215d1554a14e87416a24f8e6034312e629af7 && ./configure \
+    --enable-gpl \
+    --enable-libx264 \
+    --enable-libvmaf \
+    --enable-libdav1d \
+    --enable-nonfree \
+    --enable-cuda-nvcc \
+    --enable-libnpp \
+    --extra-cflags="-I/usr/local/cuda/include" \
+    --extra-ldflags="-L/usr/local/cuda/lib64" \
+    --disable-static \
+    --enable-shared \
+    --nvccflags="${NVCC_FLAGS}" && \
+    make -j && \
+    make install
+
+RUN set -eux; \
+    test -f /usr/local/lib/x86_64-linux-gnu/libvmaf.so.3 || test -f /usr/local/lib/libvmaf.so.3; \
+    ldconfig
+
+RUN mkdir /data
+# VMAF+decode GPU (only works for NVDec supported formats https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new)
+ENTRYPOINT ["ffmpeg"]


### PR DESCRIPTION
- VMAF calculation with libvmaf_cuda ffmpeg docker with randomised `skip_frames` and `n_subsample` for upscaling synthetics and over full video for compression synthetics, fallback to y4m if support not detected
- Color and chroma validation with signalstats ffmeg
- no y4m intermediate conversion if libvmaf_cuda ffmpeg based VMAF calculation support detected, reduces per UID scoring/evaluation time to 20-25 seconds from current 50-60+ seconds for compression
- bootstrap script to install relevant dependencies such as Docker, Nvidia CUDA drivers etc.